### PR TITLE
Reject an oversized payload on the header alone

### DIFF
--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -116,13 +116,12 @@ impl MessageReceived {
 
         let header = Header::from_raw_format(&buffer[..HEADER_LENGTH])?;
 
-        if buffer.len() < HEADER_LENGTH + header.payload_size as usize {
-            // It's possible that we partially read the input
-            return Ok((None, 0));
-        }
-
         if header.payload_size > MAX_PAYLOAD_SIZE {
             return Err(anyhow!("Payload too large: {}", header.payload_size));
+        }
+
+        if buffer.len() < HEADER_LENGTH + header.payload_size as usize {
+            return Ok((None, 0));
         }
 
         let mut reader =
@@ -154,5 +153,117 @@ impl MessageReceived {
         };
 
         Ok((Some(message), bytes_read))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    fn header_claiming(payload_size: u32) -> Vec<u8> {
+        let mut header = Vec::new();
+        header.extend_from_slice(&MAGIC_BYTES);
+        header.extend_from_slice(&crate::util::command_12(PING_COMMAND_NAME));
+        header.extend_from_slice(&payload_size.to_le_bytes());
+        header.extend_from_slice(&[0u8; 4]);
+        header
+    }
+
+    fn a_real_ping() -> Vec<u8> {
+        Message::new(Ping::new()).unwrap().get_raw_format().unwrap()
+    }
+
+    #[rstest]
+    #[case::one_over(MAX_PAYLOAD_SIZE + 1)]
+    #[case::four_gigabytes(u32::MAX)]
+    fn an_oversized_payload_is_rejected_on_the_header_alone(#[case] claimed: u32) {
+        let header = header_claiming(claimed);
+        assert_eq!(HEADER_LENGTH, header.len());
+
+        let error = MessageReceived::try_parse_message(&header)
+            .expect_err("an oversized claim must be refused before its bytes are awaited");
+
+        assert!(format!("{error:#}").contains("too large"), "got: {error:#}");
+    }
+
+    #[test]
+    fn a_payload_at_the_limit_is_not_rejected_for_being_too_large() {
+        let result = MessageReceived::try_parse_message(&header_claiming(MAX_PAYLOAD_SIZE));
+
+        assert!(
+            matches!(result, Ok((None, 0))),
+            "a claim exactly at the limit is legal and merely incomplete, got: {result:?}"
+        );
+    }
+
+    #[rstest]
+    #[case::nothing(0)]
+    #[case::half_a_header(HEADER_LENGTH / 2)]
+    #[case::one_byte_short_of_a_header(HEADER_LENGTH - 1)]
+    #[case::header_but_no_payload(HEADER_LENGTH)]
+    fn an_incomplete_message_asks_for_more_bytes(#[case] available: usize) {
+        let message = a_real_ping();
+
+        let (parsed, consumed) = MessageReceived::try_parse_message(&message[..available])
+            .expect("a partial message is not an error");
+
+        assert!(parsed.is_none(), "{available} bytes should not parse");
+        assert_eq!(
+            0, consumed,
+            "nothing may be consumed from a partial message"
+        );
+    }
+
+    #[test]
+    fn a_complete_message_parses_and_reports_what_it_consumed() {
+        let message = a_real_ping();
+
+        let (parsed, consumed) = MessageReceived::try_parse_message(&message).unwrap();
+
+        assert!(matches!(parsed, Some(MessageReceived::PingMessage(_))));
+        assert_eq!(message.len(), consumed);
+    }
+
+    #[test]
+    fn trailing_bytes_of_a_second_message_are_left_alone() {
+        let mut buffer = a_real_ping();
+        let first_length = buffer.len();
+        buffer.extend_from_slice(&a_real_ping());
+
+        let (parsed, consumed) = MessageReceived::try_parse_message(&buffer).unwrap();
+
+        assert!(parsed.is_some());
+        assert_eq!(first_length, consumed, "only the first message is consumed");
+    }
+
+    #[test]
+    fn foreign_magic_bytes_are_rejected() {
+        let mut message = a_real_ping();
+        message[0] ^= 0xff;
+
+        MessageReceived::try_parse_message(&message)
+            .expect_err("a message from another network must not be parsed");
+    }
+
+    #[test]
+    fn a_corrupted_payload_fails_its_checksum() {
+        let mut message = a_real_ping();
+        let last = message.len() - 1;
+        message[last] ^= 0xff;
+
+        let error = MessageReceived::try_parse_message(&message)
+            .expect_err("a payload that does not match its checksum must be rejected");
+
+        assert!(format!("{error:#}").contains("checksum"), "got: {error:#}");
+    }
+
+    #[test]
+    fn an_unknown_command_is_rejected() {
+        let mut message = a_real_ping();
+        message[4..16].copy_from_slice(&crate::util::command_12("notacommand"));
+
+        MessageReceived::try_parse_message(&message)
+            .expect_err("a command this node does not implement must be refused");
     }
 }

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -116,8 +116,7 @@ impl MessageReceived {
 
         let header = Header::from_raw_format(&buffer[..HEADER_LENGTH])?;
 
-        // Size before completeness: the other order treats an absurd claim as a
-        // message still arriving, and waits for bytes that never come.
+        // Size before completeness, or an absurd claim reads as a message still arriving.
         if header.payload_size > MAX_PAYLOAD_SIZE {
             return Err(anyhow!("Payload too large: {}", header.payload_size));
         }
@@ -159,11 +158,11 @@ impl MessageReceived {
 }
 
 #[cfg(test)]
-pub(crate) fn oversized_header() -> Vec<u8> {
+pub(crate) fn header_claiming(payload_size: u32) -> Vec<u8> {
     let mut header = Vec::new();
     header.extend_from_slice(&MAGIC_BYTES);
     header.extend_from_slice(&crate::util::command_12(PING_COMMAND_NAME));
-    header.extend_from_slice(&u32::MAX.to_le_bytes());
+    header.extend_from_slice(&payload_size.to_le_bytes());
     header.extend_from_slice(&[0u8; 4]);
     header
 }
@@ -172,15 +171,6 @@ pub(crate) fn oversized_header() -> Vec<u8> {
 mod tests {
     use super::*;
     use rstest::rstest;
-
-    fn header_claiming(payload_size: u32) -> Vec<u8> {
-        let mut header = Vec::new();
-        header.extend_from_slice(&MAGIC_BYTES);
-        header.extend_from_slice(&crate::util::command_12(PING_COMMAND_NAME));
-        header.extend_from_slice(&payload_size.to_le_bytes());
-        header.extend_from_slice(&[0u8; 4]);
-        header
-    }
 
     fn a_real_ping() -> (Vec<u8>, u64) {
         let ping = Ping::new();

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -66,7 +66,7 @@ impl Header {
         if bytes.len() < HEADER_LENGTH {
             return Err(anyhow!("Bytes smaller than header size"));
         }
-        let mut reader = ByteReader::new(&bytes);
+        let mut reader = ByteReader::new(bytes);
 
         let magic_bytes = reader.read_array::<4>()?;
         if magic_bytes != MAGIC_BYTES {
@@ -116,6 +116,8 @@ impl MessageReceived {
 
         let header = Header::from_raw_format(&buffer[..HEADER_LENGTH])?;
 
+        // Size before completeness: the other order treats an absurd claim as a
+        // message still arriving, and waits for bytes that never come.
         if header.payload_size > MAX_PAYLOAD_SIZE {
             return Err(anyhow!("Payload too large: {}", header.payload_size));
         }
@@ -157,6 +159,16 @@ impl MessageReceived {
 }
 
 #[cfg(test)]
+pub(crate) fn oversized_header() -> Vec<u8> {
+    let mut header = Vec::new();
+    header.extend_from_slice(&MAGIC_BYTES);
+    header.extend_from_slice(&crate::util::command_12(PING_COMMAND_NAME));
+    header.extend_from_slice(&u32::MAX.to_le_bytes());
+    header.extend_from_slice(&[0u8; 4]);
+    header
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use rstest::rstest;
@@ -170,8 +182,10 @@ mod tests {
         header
     }
 
-    fn a_real_ping() -> Vec<u8> {
-        Message::new(Ping::new()).unwrap().get_raw_format().unwrap()
+    fn a_real_ping() -> (Vec<u8>, u64) {
+        let ping = Ping::new();
+        let nonce = ping.nonce;
+        (Message::new(ping).unwrap().get_raw_format().unwrap(), nonce)
     }
 
     #[rstest]
@@ -202,8 +216,9 @@ mod tests {
     #[case::half_a_header(HEADER_LENGTH / 2)]
     #[case::one_byte_short_of_a_header(HEADER_LENGTH - 1)]
     #[case::header_but_no_payload(HEADER_LENGTH)]
+    #[case::header_and_half_a_payload(HEADER_LENGTH + 4)]
     fn an_incomplete_message_asks_for_more_bytes(#[case] available: usize) {
-        let message = a_real_ping();
+        let (message, _) = a_real_ping();
 
         let (parsed, consumed) = MessageReceived::try_parse_message(&message[..available])
             .expect("a partial message is not an error");
@@ -216,20 +231,23 @@ mod tests {
     }
 
     #[test]
-    fn a_complete_message_parses_and_reports_what_it_consumed() {
-        let message = a_real_ping();
+    fn a_complete_message_parses_back_to_what_was_serialized() {
+        let (message, nonce) = a_real_ping();
 
         let (parsed, consumed) = MessageReceived::try_parse_message(&message).unwrap();
 
-        assert!(matches!(parsed, Some(MessageReceived::PingMessage(_))));
+        match parsed {
+            Some(MessageReceived::PingMessage(ping)) => assert_eq!(nonce, ping.payload.nonce),
+            other => panic!("expected a ping, got {other:?}"),
+        }
         assert_eq!(message.len(), consumed);
     }
 
     #[test]
     fn trailing_bytes_of_a_second_message_are_left_alone() {
-        let mut buffer = a_real_ping();
+        let (mut buffer, _) = a_real_ping();
         let first_length = buffer.len();
-        buffer.extend_from_slice(&a_real_ping());
+        buffer.extend_from_slice(&a_real_ping().0);
 
         let (parsed, consumed) = MessageReceived::try_parse_message(&buffer).unwrap();
 
@@ -239,7 +257,7 @@ mod tests {
 
     #[test]
     fn foreign_magic_bytes_are_rejected() {
-        let mut message = a_real_ping();
+        let (mut message, _) = a_real_ping();
         message[0] ^= 0xff;
 
         MessageReceived::try_parse_message(&message)
@@ -248,7 +266,7 @@ mod tests {
 
     #[test]
     fn a_corrupted_payload_fails_its_checksum() {
-        let mut message = a_real_ping();
+        let (mut message, _) = a_real_ping();
         let last = message.len() - 1;
         message[last] ^= 0xff;
 
@@ -260,7 +278,7 @@ mod tests {
 
     #[test]
     fn an_unknown_command_is_rejected() {
-        let mut message = a_real_ping();
+        let (mut message, _) = a_real_ping();
         message[4..16].copy_from_slice(&crate::util::command_12("notacommand"));
 
         MessageReceived::try_parse_message(&message)

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -152,7 +152,7 @@ mod tests {
     fn an_oversized_header_fails_the_connection_rather_than_being_awaited() {
         let mut output = Vec::new();
         let mut recv_buffer = Vec::new();
-        let header = crate::messages::message::oversized_header();
+        let header = crate::messages::message::header_claiming(u32::MAX);
 
         let error = process_incoming_bytes(&mut output, &mut recv_buffer, &header)
             .expect_err("a header claiming 4 GB must fail the connection, not be waited on");

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -149,26 +149,18 @@ mod tests {
     }
 
     #[test]
-    fn an_oversized_header_ends_the_connection_instead_of_buffering() {
+    fn an_oversized_header_fails_the_connection_rather_than_being_awaited() {
         let mut output = Vec::new();
         let mut recv_buffer = Vec::new();
+        let header = crate::messages::message::oversized_header();
 
-        let mut header = Vec::new();
-        header.extend_from_slice(&[0xf9, 0xbe, 0xb4, 0xd9]);
-        header.extend_from_slice(&crate::util::command_12("ping"));
-        header.extend_from_slice(&u32::MAX.to_le_bytes());
-        header.extend_from_slice(&[0u8; 4]);
-
-        process_incoming_bytes(&mut output, &mut recv_buffer, &header)
+        let error = process_incoming_bytes(&mut output, &mut recv_buffer, &header)
             .expect_err("a header claiming 4 GB must fail the connection, not be waited on");
 
-        process_incoming_bytes(&mut output, &mut recv_buffer, &header)
-            .expect_err("and must keep failing rather than accumulating");
-
+        assert!(format!("{error:#}").contains("too large"), "got: {error:#}");
         assert!(
-            recv_buffer.len() <= 2 * header.len(),
-            "recv_buffer grew to {} bytes; an oversized claim must never be awaited",
-            recv_buffer.len()
+            output.is_empty(),
+            "nothing should be sent in reply to a header that was refused"
         );
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -149,6 +149,30 @@ mod tests {
     }
 
     #[test]
+    fn an_oversized_header_ends_the_connection_instead_of_buffering() {
+        let mut output = Vec::new();
+        let mut recv_buffer = Vec::new();
+
+        let mut header = Vec::new();
+        header.extend_from_slice(&[0xf9, 0xbe, 0xb4, 0xd9]);
+        header.extend_from_slice(&crate::util::command_12("ping"));
+        header.extend_from_slice(&u32::MAX.to_le_bytes());
+        header.extend_from_slice(&[0u8; 4]);
+
+        process_incoming_bytes(&mut output, &mut recv_buffer, &header)
+            .expect_err("a header claiming 4 GB must fail the connection, not be waited on");
+
+        process_incoming_bytes(&mut output, &mut recv_buffer, &header)
+            .expect_err("and must keep failing rather than accumulating");
+
+        assert!(
+            recv_buffer.len() <= 2 * header.len(),
+            "recv_buffer grew to {} bytes; an oversized claim must never be awaited",
+            recv_buffer.len()
+        );
+    }
+
+    #[test]
     fn receive_ping_send_pong() {
         let mut output = Vec::new();
         let mut recv_buffer = Vec::new();


### PR DESCRIPTION
Closes #19.

`try_parse_message` checked "is the payload here yet?" **before** "is the payload a plausible size?". A header claiming 4 GB matched the first check and returned `(None, 0)` — *keep reading* — so `recv_buffer` grew waiting for bytes that were never coming. `MAX_PAYLOAD_SIZE` could only fire after the node had already buffered what it was meant to refuse.

One 24-byte header, any peer, before any handshake, per connection.

## The fix is two swapped blocks. The work is the tests.

This is the only network-facing entry point in the codebase and it had **zero** tests — everything named "parse" covered `command_12` padding. Now 13:

- oversized claims (`MAX+1`, `u32::MAX`) rejected on the header alone
- a claim *exactly* at the limit is legal and merely incomplete — the boundary the swap must not overshoot
- partial input at 0, half a header, one byte short, header-only → `(None, 0)`, nothing consumed
- a complete message parses and reports its consumed length
- a second message's bytes are left for the next call
- foreign magic, corrupted payload (checksum), unknown command all rejected
- `process_incoming_bytes` fails the connection on an oversized header rather than accumulating

**Verified the tests catch the bug**: against the original order, both oversized cases FAIL; against this one they pass. A test that passes either way would have proved nothing here.

74 tests (was 60), `cargo fmt` clean. Clippy adds no new lints, and this clears one pre-existing `needless_borrow` in a file the PR already touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtGvj56DSWHejm6XFDG4tc


---

## Update — review pass applied

Both axes ran; each found a **vacuous test**, and in both cases it was the assertion the ticket's headline criterion rested on.

- `recv_buffer.len() <= 2 * header.len()` could not fail — `process_incoming_bytes` only appends what it is handed, so 48 bytes fed in can never exceed 48. It passed with the bug restored. Replaced by asserting the error names its cause and that nothing is written back to a refused peer; the new test *does* fail against the buggy order.
- The round-trip test asserted only the message variant, never the payload — against ARCHITECTURE.md invariant 6 (serialize → parse → **compare**). A parser returning a garbage nonce would have passed.
- The protocol test re-hardcoded the magic bytes and header layout that `messages/` owns, and which ADR-0011 changes to `0x41564931`. It builds from the real constants now.
- Added a partial-payload case (three of four incomplete cases hit the same branch), a one-line note on the ordering — the case `CLAUDE.md`'s comment rule explicitly protects — and cleared a `needless_borrow`.