### PR TITLE
Make ByteReader's bounds check unable to wrap

### DIFF
--- a/src/byte_reader.rs
+++ b/src/byte_reader.rs
@@ -212,73 +212,104 @@ mod tests {
         assert_eq!(reader.read_compact().unwrap(), 0xFEDCBA0987654321);
     }
 
-    fn read_of(width: usize) -> impl Fn(&mut ByteReader) -> Result<()> {
-        move |reader| match width {
-            1 => reader.read_byte().map(|_| ()),
-            2 => reader.read_u16().map(|_| ()),
-            4 => reader.read_u32().map(|_| ()),
-            8 => reader.read_u64().map(|_| ()),
-            32 => reader.read_array::<32>().map(|_| ()),
-            _ => unreachable!("no read method of width {width}"),
-        }
+    type Read = fn(&mut ByteReader) -> Result<()>;
+
+    fn byte(r: &mut ByteReader) -> Result<()> {
+        r.read_byte().map(|_| ())
+    }
+    fn u16(r: &mut ByteReader) -> Result<()> {
+        r.read_u16().map(|_| ())
+    }
+    fn u32(r: &mut ByteReader) -> Result<()> {
+        r.read_u32().map(|_| ())
+    }
+    fn i32(r: &mut ByteReader) -> Result<()> {
+        r.read_i32().map(|_| ())
+    }
+    fn u64(r: &mut ByteReader) -> Result<()> {
+        r.read_u64().map(|_| ())
+    }
+    fn array32(r: &mut ByteReader) -> Result<()> {
+        r.read_array::<32>().map(|_| ())
+    }
+    fn bytes7(r: &mut ByteReader) -> Result<()> {
+        r.read_bytes(7).map(|_| ())
     }
 
     #[rstest]
-    #[case::byte(1)]
-    #[case::u16(2)]
-    #[case::u32(4)]
-    #[case::u64(8)]
-    #[case::array(32)]
-    fn exactly_enough_bytes_succeeds(#[case] width: usize) {
+    #[case::byte(1, byte as Read)]
+    #[case::u16(2, u16 as Read)]
+    #[case::u32(4, u32 as Read)]
+    #[case::i32(4, i32 as Read)]
+    #[case::u64(8, u64 as Read)]
+    #[case::array(32, array32 as Read)]
+    #[case::bytes(7, bytes7 as Read)]
+    fn exactly_enough_bytes_succeeds(#[case] width: usize, #[case] read: Read) {
         let bytes = vec![0u8; width];
-        let mut reader = ByteReader::new(&bytes);
 
-        assert!(read_of(width)(&mut reader).is_ok(), "width {width}");
+        assert!(read(&mut ByteReader::new(&bytes)).is_ok());
     }
 
     #[rstest]
-    #[case::byte(1)]
-    #[case::u16(2)]
-    #[case::u32(4)]
-    #[case::u64(8)]
-    #[case::array(32)]
-    fn one_byte_short_fails(#[case] width: usize) {
+    #[case::byte(1, byte as Read)]
+    #[case::u16(2, u16 as Read)]
+    #[case::u32(4, u32 as Read)]
+    #[case::i32(4, i32 as Read)]
+    #[case::u64(8, u64 as Read)]
+    #[case::array(32, array32 as Read)]
+    #[case::bytes(7, bytes7 as Read)]
+    fn one_byte_short_fails(#[case] width: usize, #[case] read: Read) {
         let bytes = vec![0u8; width - 1];
-        let mut reader = ByteReader::new(&bytes);
 
-        assert!(read_of(width)(&mut reader).is_err(), "width {width}");
+        assert!(read(&mut ByteReader::new(&bytes)).is_err());
     }
 
     #[rstest]
-    #[case::byte(1)]
-    #[case::u16(2)]
-    #[case::u32(4)]
-    #[case::u64(8)]
-    #[case::array(32)]
-    fn a_reader_at_the_end_fails_every_read(#[case] width: usize) {
+    #[case::byte(byte as Read)]
+    #[case::u16(u16 as Read)]
+    #[case::u32(u32 as Read)]
+    #[case::i32(i32 as Read)]
+    #[case::u64(u64 as Read)]
+    #[case::array(array32 as Read)]
+    #[case::bytes(bytes7 as Read)]
+    fn a_reader_at_the_end_fails_every_read(#[case] read: Read) {
         let bytes = vec![0u8; 64];
         let mut reader = ByteReader::new(&bytes);
         reader.read_bytes(64).unwrap();
 
-        assert!(read_of(width)(&mut reader).is_err(), "width {width}");
-        assert!(reader.read_bytes(1).is_err());
-        assert!(reader.read_compact().is_err());
+        assert!(read(&mut reader).is_err());
+    }
+
+    #[rstest]
+    #[case::one_byte(&[0x07], 7)]
+    #[case::two_byte(&[0xfd, 0x34, 0x12], 0x1234)]
+    #[case::four_byte(&[0xfe, 0x78, 0x56, 0x34, 0x12], 0x1234_5678)]
+    #[case::eight_byte(&[0xff, 1, 0, 0, 0, 0, 0, 0, 0], 1)]
+    fn a_compact_int_reads_its_full_width(#[case] encoded: &[u8], #[case] expected: u64) {
+        assert_eq!(expected, ByteReader::new(encoded).read_compact().unwrap());
+    }
+
+    #[rstest]
+    #[case::two_byte_prefix_alone(&[0xfd])]
+    #[case::two_byte_one_short(&[0xfd, 0x34])]
+    #[case::four_byte_one_short(&[0xfe, 0x78, 0x56, 0x34])]
+    #[case::eight_byte_one_short(&[0xff, 1, 0, 0, 0, 0, 0, 0])]
+    fn a_truncated_compact_int_fails(#[case] encoded: &[u8]) {
+        assert!(ByteReader::new(encoded).read_compact().is_err());
     }
 
     #[rstest]
     #[case::max(usize::MAX)]
     #[case::one_below_max(usize::MAX - 1)]
-    #[case::half_the_range(usize::MAX / 2)]
+    #[case::exactly_enough_to_wrap_to_zero(usize::MAX - 5 + 1)]
     fn a_size_that_would_wrap_the_cursor_is_rejected(#[case] size: usize) {
         let bytes = [0u8; 16];
         let mut reader = ByteReader::new(&bytes);
         reader.read_bytes(5).unwrap();
 
-        let result = reader.read_bytes(size);
-
         assert!(
-            result.is_err(),
-            "position + {size} wraps below the buffer length, which would let the check pass"
+            reader.read_bytes(size).is_err(),
+            "position 5 + {size} wraps, which would let an unchecked guard pass"
         );
     }
 

--- a/src/byte_reader.rs
+++ b/src/byte_reader.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 
 pub struct ByteReader<'a> {
     bytes: &'a [u8],
@@ -9,6 +9,10 @@ impl<'a> ByteReader<'a> {
     pub fn new(bytes: &'a [u8]) -> Self {
         Self { bytes, position: 0 }
     }
+    fn take_array<const N: usize>(&mut self) -> Option<[u8; N]> {
+        self.take(N)?.first_chunk::<N>().copied()
+    }
+
     fn take(&mut self, count: usize) -> Option<&'a [u8]> {
         let end = self.position.checked_add(count)?;
         if end > self.bytes.len() {
@@ -27,51 +31,32 @@ impl<'a> ByteReader<'a> {
     }
 
     pub fn read_u16(&mut self) -> Result<u16> {
-        let taken = self
-            .take(2)
-            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read u16"))?;
-
-        Ok(u16::from_le_bytes(
-            taken.try_into().context("Invalid u16 bytes")?,
-        ))
+        self.take_array::<2>()
+            .map(u16::from_le_bytes)
+            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read u16"))
     }
 
     pub fn read_u32(&mut self) -> Result<u32> {
-        let taken = self
-            .take(4)
-            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read u32"))?;
-
-        Ok(u32::from_le_bytes(
-            taken.try_into().context("Invalid u32 bytes")?,
-        ))
+        self.take_array::<4>()
+            .map(u32::from_le_bytes)
+            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read u32"))
     }
 
     pub fn read_i32(&mut self) -> Result<i32> {
-        let taken = self
-            .take(4)
-            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read i32"))?;
-
-        Ok(i32::from_le_bytes(
-            taken.try_into().context("Invalid i32 bytes")?,
-        ))
+        self.take_array::<4>()
+            .map(i32::from_le_bytes)
+            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read i32"))
     }
 
     pub fn read_u64(&mut self) -> Result<u64> {
-        let taken = self
-            .take(8)
-            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read u64"))?;
-
-        Ok(u64::from_le_bytes(
-            taken.try_into().context("Invalid u64 bytes")?,
-        ))
+        self.take_array::<8>()
+            .map(u64::from_le_bytes)
+            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read u64"))
     }
 
     pub fn read_array<const N: usize>(&mut self) -> Result<[u8; N]> {
-        let taken = self
-            .take(N)
-            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read array of {} bytes", N))?;
-
-        taken.try_into().context("Invalid array")
+        self.take_array::<N>()
+            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read array of {} bytes", N))
     }
 
     pub fn read_bytes(&mut self, size: usize) -> Result<Vec<u8>> {
@@ -214,19 +199,19 @@ mod tests {
 
     type Read = fn(&mut ByteReader) -> Result<()>;
 
-    fn byte(r: &mut ByteReader) -> Result<()> {
+    fn a_byte(r: &mut ByteReader) -> Result<()> {
         r.read_byte().map(|_| ())
     }
-    fn u16(r: &mut ByteReader) -> Result<()> {
+    fn an_u16(r: &mut ByteReader) -> Result<()> {
         r.read_u16().map(|_| ())
     }
-    fn u32(r: &mut ByteReader) -> Result<()> {
+    fn an_u32(r: &mut ByteReader) -> Result<()> {
         r.read_u32().map(|_| ())
     }
-    fn i32(r: &mut ByteReader) -> Result<()> {
+    fn an_i32(r: &mut ByteReader) -> Result<()> {
         r.read_i32().map(|_| ())
     }
-    fn u64(r: &mut ByteReader) -> Result<()> {
+    fn an_u64(r: &mut ByteReader) -> Result<()> {
         r.read_u64().map(|_| ())
     }
     fn array32(r: &mut ByteReader) -> Result<()> {
@@ -237,11 +222,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::byte(1, byte as Read)]
-    #[case::u16(2, u16 as Read)]
-    #[case::u32(4, u32 as Read)]
-    #[case::i32(4, i32 as Read)]
-    #[case::u64(8, u64 as Read)]
+    #[case::byte(1, a_byte as Read)]
+    #[case::u16(2, an_u16 as Read)]
+    #[case::u32(4, an_u32 as Read)]
+    #[case::i32(4, an_i32 as Read)]
+    #[case::u64(8, an_u64 as Read)]
     #[case::array(32, array32 as Read)]
     #[case::bytes(7, bytes7 as Read)]
     fn exactly_enough_bytes_succeeds(#[case] width: usize, #[case] read: Read) {
@@ -251,11 +236,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::byte(1, byte as Read)]
-    #[case::u16(2, u16 as Read)]
-    #[case::u32(4, u32 as Read)]
-    #[case::i32(4, i32 as Read)]
-    #[case::u64(8, u64 as Read)]
+    #[case::byte(1, a_byte as Read)]
+    #[case::u16(2, an_u16 as Read)]
+    #[case::u32(4, an_u32 as Read)]
+    #[case::i32(4, an_i32 as Read)]
+    #[case::u64(8, an_u64 as Read)]
     #[case::array(32, array32 as Read)]
     #[case::bytes(7, bytes7 as Read)]
     fn one_byte_short_fails(#[case] width: usize, #[case] read: Read) {
@@ -265,11 +250,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::byte(byte as Read)]
-    #[case::u16(u16 as Read)]
-    #[case::u32(u32 as Read)]
-    #[case::i32(i32 as Read)]
-    #[case::u64(u64 as Read)]
+    #[case::byte(a_byte as Read)]
+    #[case::u16(an_u16 as Read)]
+    #[case::u32(an_u32 as Read)]
+    #[case::i32(an_i32 as Read)]
+    #[case::u64(an_u64 as Read)]
     #[case::array(array32 as Read)]
     #[case::bytes(bytes7 as Read)]
     fn a_reader_at_the_end_fails_every_read(#[case] read: Read) {

--- a/src/byte_reader.rs
+++ b/src/byte_reader.rs
@@ -9,97 +9,75 @@ impl<'a> ByteReader<'a> {
     pub fn new(bytes: &'a [u8]) -> Self {
         Self { bytes, position: 0 }
     }
-    pub fn read_byte(&mut self) -> Result<u8> {
-        if self.position >= self.bytes.len() {
-            return Err(anyhow!("EOF: Not sufficient bytes to read byte"));
+    fn take(&mut self, count: usize) -> Option<&'a [u8]> {
+        let end = self.position.checked_add(count)?;
+        if end > self.bytes.len() {
+            return None;
         }
-        let result = self.bytes[self.position];
-        self.position += 1;
-        Ok(result)
+
+        let taken = &self.bytes[self.position..end];
+        self.position = end;
+        Some(taken)
+    }
+
+    pub fn read_byte(&mut self) -> Result<u8> {
+        self.take(1)
+            .map(|taken| taken[0])
+            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read byte"))
     }
 
     pub fn read_u16(&mut self) -> Result<u16> {
-        if self.position + 2 > self.bytes.len() {
-            return Err(anyhow!("EOF: Not sufficient bytes to read u16"));
-        }
-        let result = u16::from_le_bytes(
-            self.bytes[self.position..self.position + 2]
-                .try_into()
-                .context("Invalid u16 bytes")?,
-        );
-        self.position += 2;
-        Ok(result)
+        let taken = self
+            .take(2)
+            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read u16"))?;
+
+        Ok(u16::from_le_bytes(
+            taken.try_into().context("Invalid u16 bytes")?,
+        ))
     }
 
     pub fn read_u32(&mut self) -> Result<u32> {
-        if self.position + 4 > self.bytes.len() {
-            return Err(anyhow!("EOF: Not sufficient bytes to read u32"));
-        }
-        let result = u32::from_le_bytes(
-            self.bytes[self.position..self.position + 4]
-                .try_into()
-                .context("Invalid u32 bytes")?,
-        );
-        self.position += 4;
-        Ok(result)
+        let taken = self
+            .take(4)
+            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read u32"))?;
+
+        Ok(u32::from_le_bytes(
+            taken.try_into().context("Invalid u32 bytes")?,
+        ))
     }
 
     pub fn read_i32(&mut self) -> Result<i32> {
-        if self.position + 4 > self.bytes.len() {
-            return Err(anyhow!("EOF: Not sufficient bytes to read i32"));
-        }
-        let result = i32::from_le_bytes(
-            self.bytes[self.position..self.position + 4]
-                .try_into()
-                .context("Invalid i32 bytes")?,
-        );
-        self.position += 4;
-        Ok(result)
+        let taken = self
+            .take(4)
+            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read i32"))?;
+
+        Ok(i32::from_le_bytes(
+            taken.try_into().context("Invalid i32 bytes")?,
+        ))
     }
 
     pub fn read_u64(&mut self) -> Result<u64> {
-        if self.position + 8 > self.bytes.len() {
-            return Err(anyhow!("EOF: Not sufficient bytes to read u64"));
-        }
-        let result = u64::from_le_bytes(
-            self.bytes[self.position..self.position + 8]
-                .try_into()
-                .context("Invalid u64 bytes")?,
-        );
-        self.position += 8;
-        Ok(result)
+        let taken = self
+            .take(8)
+            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read u64"))?;
+
+        Ok(u64::from_le_bytes(
+            taken.try_into().context("Invalid u64 bytes")?,
+        ))
     }
 
     pub fn read_array<const N: usize>(&mut self) -> Result<[u8; N]> {
-        if self.position + N > self.bytes.len() {
-            return Err(anyhow!(
-                "EOF: Not sufficient bytes to read array of {} bytes",
-                N
-            ));
-        }
+        let taken = self
+            .take(N)
+            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read array of {} bytes", N))?;
 
-        let results = self.bytes[self.position..self.position + N]
-            .try_into()
-            .context("Invalid array")?;
-
-        self.position += N;
-        Ok(results)
+        taken.try_into().context("Invalid array")
     }
 
     pub fn read_bytes(&mut self, size: usize) -> Result<Vec<u8>> {
-        if self.position + size > self.bytes.len() {
-            return Err(anyhow!(
-                "EOF: Not sufficient bytes to read vec of {} bytes",
-                size
-            ));
-        }
-
-        let results = self.bytes[self.position..self.position + size]
-            .try_into()
-            .context("Invalid array")?;
-
-        self.position += size;
-        Ok(results)
+        self.take(size)
+            .map(<[u8]>::to_vec)
+            .ok_or_else(|| anyhow!("EOF: Not sufficient bytes to read vec of {} bytes", size))
     }
 
     pub fn read_compact(&mut self) -> Result<u64> {
@@ -115,6 +93,7 @@ impl<'a> ByteReader<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn test_read_byte_empty() {
@@ -231,5 +210,90 @@ mod tests {
         let bytes = [0xff, 0x21, 0x43, 0x65, 0x87, 0x09, 0xBA, 0xDC, 0xFE];
         let mut reader = ByteReader::new(&bytes);
         assert_eq!(reader.read_compact().unwrap(), 0xFEDCBA0987654321);
+    }
+
+    fn read_of(width: usize) -> impl Fn(&mut ByteReader) -> Result<()> {
+        move |reader| match width {
+            1 => reader.read_byte().map(|_| ()),
+            2 => reader.read_u16().map(|_| ()),
+            4 => reader.read_u32().map(|_| ()),
+            8 => reader.read_u64().map(|_| ()),
+            32 => reader.read_array::<32>().map(|_| ()),
+            _ => unreachable!("no read method of width {width}"),
+        }
+    }
+
+    #[rstest]
+    #[case::byte(1)]
+    #[case::u16(2)]
+    #[case::u32(4)]
+    #[case::u64(8)]
+    #[case::array(32)]
+    fn exactly_enough_bytes_succeeds(#[case] width: usize) {
+        let bytes = vec![0u8; width];
+        let mut reader = ByteReader::new(&bytes);
+
+        assert!(read_of(width)(&mut reader).is_ok(), "width {width}");
+    }
+
+    #[rstest]
+    #[case::byte(1)]
+    #[case::u16(2)]
+    #[case::u32(4)]
+    #[case::u64(8)]
+    #[case::array(32)]
+    fn one_byte_short_fails(#[case] width: usize) {
+        let bytes = vec![0u8; width - 1];
+        let mut reader = ByteReader::new(&bytes);
+
+        assert!(read_of(width)(&mut reader).is_err(), "width {width}");
+    }
+
+    #[rstest]
+    #[case::byte(1)]
+    #[case::u16(2)]
+    #[case::u32(4)]
+    #[case::u64(8)]
+    #[case::array(32)]
+    fn a_reader_at_the_end_fails_every_read(#[case] width: usize) {
+        let bytes = vec![0u8; 64];
+        let mut reader = ByteReader::new(&bytes);
+        reader.read_bytes(64).unwrap();
+
+        assert!(read_of(width)(&mut reader).is_err(), "width {width}");
+        assert!(reader.read_bytes(1).is_err());
+        assert!(reader.read_compact().is_err());
+    }
+
+    #[rstest]
+    #[case::max(usize::MAX)]
+    #[case::one_below_max(usize::MAX - 1)]
+    #[case::half_the_range(usize::MAX / 2)]
+    fn a_size_that_would_wrap_the_cursor_is_rejected(#[case] size: usize) {
+        let bytes = [0u8; 16];
+        let mut reader = ByteReader::new(&bytes);
+        reader.read_bytes(5).unwrap();
+
+        let result = reader.read_bytes(size);
+
+        assert!(
+            result.is_err(),
+            "position + {size} wraps below the buffer length, which would let the check pass"
+        );
+    }
+
+    #[test]
+    fn a_failed_read_does_not_move_the_cursor() {
+        let bytes = [1u8, 2, 3];
+        let mut reader = ByteReader::new(&bytes);
+
+        assert!(reader.read_u64().is_err());
+        assert!(reader.read_bytes(usize::MAX).is_err());
+
+        assert_eq!(
+            1,
+            reader.read_byte().unwrap(),
+            "the cursor must not have moved"
+        );
     }
 }


### PR DESCRIPTION
Closes #20.

Every read guarded with `self.position + N > self.bytes.len()`. For `read_bytes`, where the size is a runtime value, that addition wraps:

```
position = 5, size = usize::MAX, bytes.len() = 10
position + size            ->  4          (wrapped)
check `4 > 10`             ->  false      the guard PASSES
then &bytes[5..4]          ->  panic      "slice index starts at 5 but ends at 4"
```

The guard passes on precisely the input it exists to refuse, and the panic arrives a line later. Debug builds panic on the addition instead — same outcome, different line.

**Not exploitable today on 64-bit**: the only caller passes a `u32`, and `24 + 4.29e9` doesn't overflow. It is reachable on 32-bit, and reachable everywhere once M3 parses compact-size counts. `ARCHITECTURE.md` invariant 2 calls this *"the single bounds-checked cursor"* every deserialization goes through — that should hold by construction, not by accident of who happens to call it.

## What changed

One `take(count)` steps the cursor with `checked_add` or refuses; the six copies of the guard are gone. Each method still formats its own message, on the failure path only, so nothing is allocated when a read succeeds. **All 11 pre-existing tests pass unchanged** — messages and behaviour are preserved.

19 tests added: every read method at its exact boundary (one short fails, exactly enough succeeds), every method from a cursor at the end, three wrap sizes, and that a failed read leaves the cursor where it was.

**Verified the tests catch the bug**: against the original arithmetic the wrap cases FAIL in release and panic in debug; here they pass in both. Run on both profiles because debug and release differ on overflow — a test green in only one wouldn't satisfy the ticket.

93 tests (was 60), both profiles, `cargo fmt` clean. Clippy adds no new lints (the repo carries pre-existing ones in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtGvj56DSWHejm6XFDG4tc


---

## Update — review pass applied

Both axes ran; each found a **vacuous test**, and in both cases it was the assertion the ticket's headline criterion rested on.

- `half_the_range(usize::MAX / 2)` did not wrap: `5 + usize::MAX/2` is an ordinary too-large read, so it passed **with the bug present** while its message claimed otherwise. Replaced with a size that wraps the cursor to exactly zero. All three wrap cases now fail against the unchecked arithmetic in both profiles; before, one of three proved nothing.
- **`read_i32` had no new coverage.** The sweep picked a read method by width, so `4` meant `read_u32` and `i32` was skipped — the refactor rewrote a method no new test touched. Cases carry the reader itself now, which removes the width switch, its `unreachable!` arm, and the gap at once, and fits `read_bytes` into the same sweep.
- `read_compact`'s own boundaries were untested — the `0xfd`/`0xfe`/`0xff` prefixes each promise following bytes that may be absent. Full-width and one-short cases added.