### PR TITLE
Hash with sha2 instead of the sha256 wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,17 +74,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,23 +91,8 @@ dependencies = [
  "rstest",
  "secp256k1",
  "serde",
- "sha256",
+ "sha2",
  "toml",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets",
 ]
 
 [[package]]
@@ -190,12 +149,6 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "bytes"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -461,12 +414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,24 +528,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -862,12 +791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,19 +901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha256"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f880fc8562bdeb709793f00eb42a2ad0e672c4f883bbe59122b926eca935c8f6"
-dependencies = [
- "async-trait",
- "bytes",
- "hex",
- "sha2",
- "tokio",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,17 +954,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tokio"
-version = "1.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
-dependencies = [
- "backtrace",
- "bytes",
- "pin-project-lite",
-]
 
 [[package]]
 name = "toml"
@@ -1235,70 +1134,6 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-hex = "0.4.3"
 primitive-types = "0.14.0"
-sha256 = "1.5.0"
+sha2 = "0.10.9"
 anyhow = "1.0.98"
 secp256k1 = { version = "0.31.1", features = ["rand", "std", "hashes"] }
 rand = "0.10.0"
@@ -15,4 +14,5 @@ toml = "1.1.2+spec-1.1.0"
 clap = { version = "4.6.1", features = ["derive"] }
 
 [dev-dependencies]
+hex = "0.4.3"
 rstest = "0.26.1"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,18 +117,28 @@ The rules are in `CLAUDE.md`; this is the crate-by-crate consequence of them and
 the authority when the two disagree on a specific crate.
 
 The governing decision: **keep the crates already in the tree** — no rewrites
-merely to drop a dependency. The *only* crate removed is `secp256k1`, because it
-wraps Bitcoin Core's libsecp256k1 and violates the "no Bitcoin-specific library"
-rule. That removal is a crate-for-crate swap, not a hand-roll.
+merely to drop a dependency. Two crates are removed, and in both cases a rule
+forced it rather than taste:
+
+- **`secp256k1`** wraps Bitcoin Core's libsecp256k1, breaking "no
+  Bitcoin-specific library". Replaced by `k256`.
+- **`sha256`** was a wrapper over `sha2` whose conveniences we never used. It
+  returned hex strings, so `get_hash` decoded back to bytes twice per call —
+  5.5× slower than hashing directly, on the function `Block::mine()` runs in its
+  nonce loop. It also pulled `tokio`, `async-trait` and `bytes` into the tree
+  (without tokio's runtime feature, so nothing async ever ran — but 20 crates
+  for a wrapper). Replaced by `sha2`, the crate it wrapped.
+
+Both are crate-for-crate swaps, not hand-rolls.
 
 | Concern | Decision |
 |---|---|
-| ECDSA / secp256k1 signing | **Swap** `secp256k1` → RustCrypto **`k256`**. The one crate dropped. |
-| SHA-256 | **Keep** `sha256`. |
+| ECDSA / secp256k1 signing | **Swap** `secp256k1` → RustCrypto **`k256`**. |
+| SHA-256 | **`sha2`** (RustCrypto), same family as `k256` and `ripemd`. |
 | Error handling | **Keep** `anyhow` — it already threads through every `ByteReader` read and call site. |
 | Config / CLI | **Keep** `toml` + `serde`; **`clap`** parses CLI arguments. |
 | Big-int target math | **Keep** `primitive-types` (`U256`). |
-| Hex, randomness | **Keep** `hex` and `rand` (key material comes from `rand`). |
+| Hex, randomness | **Keep** `rand` (key material comes from `rand`). `hex` is now used only by tests and lives in `[dev-dependencies]`; it returns to `[dependencies]` when something displays a hash. |
 | RIPEMD160 | **Add** `ripemd` (RustCrypto). ADR-0002: the HASH160 *composition* is Bitcoin's and is hand-rolled; RIPEMD160 itself is general-purpose cryptography from 1996. `sha2` and `digest` are already in `Cargo.lock`, so this adds no new transitive weight. |
 | Block index & UTXO storage | **Add** `redb` (embedded key-value store). ADR-0013: this mirrors Bitcoin's own split — it hand-rolls block files and delegates its databases to LevelDB. The flat files are ours; a B-tree is generic plumbing. |
 | JSON | **Add** `serde_json` (`serde` already present). |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,8 +117,8 @@ The rules are in `CLAUDE.md`; this is the crate-by-crate consequence of them and
 the authority when the two disagree on a specific crate.
 
 The governing decision: **keep the crates already in the tree** — no rewrites
-merely to drop a dependency. Two crates are removed, and in both cases a rule
-forced it rather than taste:
+merely to drop a dependency. Two crates are removed, each for a reason that
+outweighs that:
 
 - **`secp256k1`** wraps Bitcoin Core's libsecp256k1, breaking "no
   Bitcoin-specific library". Replaced by `k256`.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,19 +1,8 @@
 use anyhow::{anyhow, Context, Result};
-use hex::decode;
-use sha256::digest;
+use sha2::{Digest, Sha256};
 
 pub fn get_hash(slice: &[u8]) -> [u8; 32] {
-    let pass1_hex = digest(slice);
-    let pass1_raw = decode(pass1_hex).expect("Failed to decode pass 1");
-
-    let pass2_hex = digest(pass1_raw);
-    let pass2_raw = decode(pass2_hex).expect("Failed to decode pass 2");
-
-    let pass2_raw = pass2_raw
-        .try_into()
-        .expect("Failed to convert pass2 to array");
-
-    pass2_raw
+    Sha256::digest(Sha256::digest(slice)).into()
 }
 
 pub fn get_compact_int(number: u64) -> Vec<u8> {
@@ -73,6 +62,7 @@ pub fn parse_command_12(cmd_bytes: &[u8; 12]) -> Result<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hex::decode;
 
     #[test]
     fn get_hash_known_input() {


### PR DESCRIPTION
Closes #25.

## The part I got wrong in the ticket

#25 framed this as a **hard-rule violation** — `CLAUDE.md` says "no async runtime" and `sha256` pulls `tokio`. Review pushed back and was right: tokio arrived **without its runtime feature** (`backtrace`, `bytes`, `pin-project-lite` — no `rt`, no `mio`), so no async runtime was ever compiled in. And `sha256 = { default-features = false }` would have dropped the whole subtree in **one line, zero code change** — which is what `CLAUDE.md`'s "don't rewrite working code just to drop a dependency" would prefer.

So the dependency argument alone did **not** justify a swap.

## The reason that does

`get_hash` went through hex twice per call. The `sha256` crate returns a hex `String`, so each pass was `digest → String → decode`:

```rust
let pass1_hex = digest(slice);
let pass1_raw = decode(pass1_hex).expect("Failed to decode pass 1");
let pass2_hex = digest(pass1_raw);
let pass2_raw = decode(pass2_hex).expect("Failed to decode pass 2");
```

Measured over 200k iterations of an 80-byte header:

| | |
|---|---|
| old (hex round-trips) | **95.0 ms** |
| new (`sha2` direct) | **17.2 ms** |
| | **5.5× faster** |

`Block::mine()` calls `get_hash` in its nonce loop, and it is also every txid, block hash and merkle node. `default-features = false` would not have touched this. It now reads:

```rust
Sha256::digest(Sha256::digest(slice)).into()
```

Three `.expect()` panic paths go with it.

## Also

- **163 → 143 packages.** `tokio`, `async-trait`, `bytes` and their subtrees are gone — verified with `cargo tree -i`. This clears the one *medium* Dependabot alert (`bytes`, integer overflow in `BytesMut::reserve`).
- `sha2` is the crate `sha256` was wrapping, and the family `k256` and `ripemd` join in M3.
- `hex` is now reached only from test modules → moved to `[dev-dependencies]`. It returns when something displays a hash.

## Verification

`get_hash_known_input` pins the digest against a **real mainnet block header**, so it fails on single-SHA, wrong endianness or truncation. It passes **unchanged** — no test body was touched, only an import moved into the test module. 107 tests, debug and release. Independently confirmed against `python3 hashlib` on four inputs.

Two doc corrections came out of review: I had rewritten "`sha2` and `digest` are already in `Cargo.lock`" (true) into "already direct dependencies" (false — `digest` is transitive via `sha2`), and had overstated the tokio claim. Both fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtGvj56DSWHejm6XFDG4tc