### PR TITLE
Introduce Node and SharedNode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use crate::config::get_config;
+use crate::node::Node;
 use crate::protocol::{connect, listen};
 use anyhow::{Context, Result};
 use std::net::TcpListener;
+use std::sync::Arc;
 use std::thread;
 
 mod block;
@@ -9,28 +11,38 @@ mod block_storage;
 mod byte_reader;
 mod config;
 mod messages;
+mod node;
 mod protocol;
 mod transaction;
 mod util;
 mod wallet;
 
 fn main() -> Result<()> {
-    let config = get_config()?;
+    let node = Node::shared(get_config()?);
+
+    let (host_address, addresses_to_connect) = {
+        let node = node.lock().expect("node lock poisoned");
+        (
+            node.config.host_address,
+            node.config.addresses_to_connect.clone(),
+        )
+    };
 
     // Bound here, not in the thread: a bind failure must fail the process.
-    let listener = TcpListener::bind(config.host_address)
-        .with_context(|| format!("could not listen on {}", config.host_address))?;
+    let listener = TcpListener::bind(host_address)
+        .with_context(|| format!("could not listen on {host_address}"))?;
 
     println!("Listening on {}", listener.local_addr()?);
 
-    if config.addresses_to_connect.is_empty() {
+    if addresses_to_connect.is_empty() {
         println!("No peers configured; waiting for inbound connections");
     }
 
-    let handle = thread::spawn(move || listen(listener));
+    let listening_node = Arc::clone(&node);
+    let handle = thread::spawn(move || listen(listener, listening_node));
 
-    for addr in config.addresses_to_connect {
-        if let Err(e) = connect(addr) {
+    for addr in addresses_to_connect {
+        if let Err(e) = connect(addr, Arc::clone(&node)) {
             println!("Could not connect to {addr}: {e:#}");
         }
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -27,20 +27,27 @@ mod tests {
     }
 
     #[test]
-    fn the_handle_can_be_locked_from_a_connection_thread() {
+    fn every_connection_thread_holds_the_same_node_not_a_copy() {
         let node = Node::shared(config());
 
-        let connection = {
-            let node = Arc::clone(&node);
-            thread::spawn(move || node.lock().unwrap().config.host_address)
-        };
+        let threads: Vec<_> = (0..4)
+            .map(|_| {
+                let node = Arc::clone(&node);
+                thread::spawn(move || {
+                    let address = node.lock().unwrap().config.host_address;
+                    (node, address)
+                })
+            })
+            .collect();
 
-        let observed = connection.join().unwrap();
-        let expected = node.lock().unwrap().config.host_address;
+        for thread in threads {
+            let (observed, address) = thread.join().unwrap();
 
-        assert_eq!(
-            expected, observed,
-            "a connection thread reads node state through the shared handle"
-        );
+            assert!(
+                Arc::ptr_eq(&node, &observed),
+                "a connection thread must share the node, not receive a copy of it"
+            );
+            assert_eq!(node.lock().unwrap().config.host_address, address);
+        }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,0 +1,46 @@
+use crate::config::Config;
+use std::sync::{Arc, Mutex};
+
+pub type SharedNode = Arc<Mutex<Node>>;
+
+#[derive(Debug)]
+pub struct Node {
+    pub config: Config,
+}
+
+impl Node {
+    pub fn shared(config: Config) -> SharedNode {
+        Arc::new(Mutex::new(Self { config }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    fn config() -> Config {
+        Config {
+            host_address: "127.0.0.1:34352".parse().unwrap(),
+            addresses_to_connect: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn the_handle_can_be_locked_from_a_connection_thread() {
+        let node = Node::shared(config());
+
+        let connection = {
+            let node = Arc::clone(&node);
+            thread::spawn(move || node.lock().unwrap().config.host_address)
+        };
+
+        let observed = connection.join().unwrap();
+        let expected = node.lock().unwrap().config.host_address;
+
+        assert_eq!(
+            expected, observed,
+            "a connection thread reads node state through the shared handle"
+        );
+    }
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -2,25 +2,27 @@ use crate::messages::message::MessageReceived::{PingMessage, PongMessage};
 use crate::messages::message::{Message, MessageReceived};
 use crate::messages::ping::Ping;
 use crate::messages::pong::Pong;
+use crate::node::SharedNode;
 use anyhow::{anyhow, Result};
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
 const PING_INTERVAL: Duration = Duration::from_secs(11);
 
-pub fn connect(addr: SocketAddr) -> Result<()> {
+pub fn connect(addr: SocketAddr, node: SharedNode) -> Result<()> {
     let stream = TcpStream::connect(addr)?;
-    spawn_connection(stream);
+    spawn_connection(stream, node);
 
     Ok(())
 }
 
-pub fn listen(listener: TcpListener) -> Result<()> {
+pub fn listen(listener: TcpListener, node: SharedNode) -> Result<()> {
     for stream in listener.incoming() {
         match stream {
-            Ok(stream) => spawn_connection(stream),
+            Ok(stream) => spawn_connection(stream, Arc::clone(&node)),
             Err(e) => println!("Could not accept a connection: {e}"),
         }
     }
@@ -32,7 +34,7 @@ fn ping_is_due(last_ping: Option<Instant>, now: Instant, interval: Duration) -> 
     last_ping.is_none_or(|sent| now.saturating_duration_since(sent) >= interval)
 }
 
-fn spawn_connection(stream: TcpStream) {
+fn spawn_connection(stream: TcpStream, node: SharedNode) {
     thread::spawn(move || {
         let peer = match stream.peer_addr() {
             Ok(peer) => peer,
@@ -42,16 +44,17 @@ fn spawn_connection(stream: TcpStream) {
             }
         };
 
-        if let Err(e) = handle_connection(stream, peer) {
+        if let Err(e) = handle_connection(stream, peer, node) {
             println!("Connection with {peer} ended: {e:#}");
         }
     });
 }
 
-fn handle_connection(mut stream: TcpStream, peer_addr: SocketAddr) -> Result<()> {
+fn handle_connection(mut stream: TcpStream, peer_addr: SocketAddr, node: SharedNode) -> Result<()> {
     stream.set_read_timeout(Some(Duration::from_secs(5)))?;
 
-    println!("Handling connection from {peer_addr}");
+    let host_address = node.lock().expect("node lock poisoned").config.host_address;
+    println!("{host_address} is handling a connection from {peer_addr}");
     let mut buffer = [0u8; 4096];
     let mut recv_buffer: Vec<u8> = Vec::new();
 


### PR DESCRIPTION
Closes #14.

Prefactor: establishes where node-wide state lives, so the tickets that follow have somewhere to put it. No behaviour changes beyond one log line.

## The design call the ticket didn't resolve

#14 says `Node` holds "the peer registry and the log buffer" — but the peer registry is **#16's** deliverable and the log buffer is **#17's**, and #16 is itself blocked by this ticket. Landing empty placeholders for both would be dead code that those tickets rewrite rather than grow.

So `Node` holds **exactly one field: `config`** — the only node-wide state that already exists, is already resolved once at startup, and already has readers. #16 and #17 grow it.

That gives the handle two real readers today rather than zero:
1. `main` locks once at startup for the bind address and peer list
2. `handle_connection` reads `config.host_address` to label its greeting with *both* ends — which is why the two-node logs below are distinguishable

Two smaller calls, both worth disagreeing with if you'd rather:
- **`SharedNode` is a type alias**, as `ARCHITECTURE.md` sketches, not a newtype with a `lock()` helper. A newtype would centralise poison handling, but deviates from the documented shape for two call sites.
- **A poisoned lock panics** rather than recovering via `PoisonError::into_inner`. With one mutex over the whole node, continuing on state a panicking thread abandoned is the worse failure. Unspecified by the ticket.

## Verified

- 108 tests (107 + 1), debug **and** release; no existing test modified
- `cargo fmt --check` clean; clippy clean on all three touched files
- **Two real nodes, no `config.toml`, CLI-configured** — ping/pong crosses in both directions with matching nonces:

```
A: 127.0.0.1:34951 is handling a connection from 127.0.0.1:55624
   Ping received nonce 15552616212934250584
   Pong received nonce 6619916822990302373
B: 127.0.0.1:34952 is handling a connection from 127.0.0.1:34951
   Ping received nonce 6619916822990302373
   Pong received nonce 15552616212934250584
```

There is no e2e suite yet (ADR-0001 puts it in M7), so this is a manual check.

## Knock-on for #17

#17 assumes `main.rs`'s startup `println!`s "run before any `Node` exists". They no longer do — `Node` now owns the config, so it is constructed *before* the "Listening on" line and all three startup lines are reachable by the buffer. That constraint has gone away; #17 should be updated when it's picked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtGvj56DSWHejm6XFDG4tc