### PR TITLE
Clear the clippy lints before CI starts gating on them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.98"
 secp256k1 = { version = "0.31.1", features = ["rand", "std", "hashes"] }
 rand = "0.10.0"
 serde = { version = "1.0.228", features = ["derive"] }
-toml = "1.1.2+spec-1.1.0"
+toml = "1.1.2"
 clap = { version = "4.6.1", features = ["derive"] }
 
 [dev-dependencies]

--- a/src/block.rs
+++ b/src/block.rs
@@ -85,13 +85,13 @@ impl Block {
         let mantissa = target & 0x007FFFFF;
 
         let target = U256::from(mantissa);
-        target << exponent * 8
+        target << (exponent * 8)
     }
 
     fn get_merkle_root_hash(&self) -> Result<[u8; 32]> {
         let mut ids: Vec<[u8; 32]> = self.transactions.iter().map(|tx| tx.get_tx_id()).collect();
 
-        if ids.len() == 0 {
+        if ids.is_empty() {
             return Ok([0u8; 32]);
         }
 
@@ -100,7 +100,7 @@ impl Block {
 
             while count > 0 {
                 let tx_id_1 = ids.pop().context("Invalid tx_id(1) array")?;
-                count = count - 1;
+                count -= 1;
                 let tx_id_2 = match count {
                     0 => tx_id_1,
                     _ => ids.pop().context("Invalid tx_id(2) array")?,
@@ -108,16 +108,14 @@ impl Block {
                 let concat = [&tx_id_1[..], &tx_id_2[..]].concat();
                 let hash = get_hash(concat.as_slice());
                 ids.push(hash);
-                if count > 0 {
-                    count = count - 1;
-                }
+                count = count.saturating_sub(1);
             }
         }
         Ok(ids[0])
     }
 
     pub fn get_raw_format(&self) -> Result<Vec<u8>> {
-        if self.hash == None {
+        if self.hash.is_none() {
             return Err(anyhow!(
                 "Hash is empty, you need to mine or assign a hash to the block"
             ));
@@ -182,7 +180,7 @@ mod tests {
     fn mines_generates_correct_hash(#[case] number_of_transactions: usize) {
         let mut block = get_block(number_of_transactions);
 
-        assert_eq!(block.mine().unwrap(), true);
+        assert!(block.mine().unwrap());
     }
 
     #[test]

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -31,7 +31,7 @@ pub struct TxOut {
 
 impl Transaction {
     pub fn get_tx_id(&self) -> [u8; 32] {
-        get_hash(&self.get_raw_format().as_slice())
+        get_hash(self.get_raw_format().as_slice())
     }
 
     pub fn get_raw_format(&self) -> Vec<u8> {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -30,7 +30,7 @@ impl Wallet {
         }
 
         // get available utxo
-        let outpoints = Self::get_outpoints(amount, fee);
+        let outpoints = Self::get_outpoints();
 
         let secp = Secp256k1::signing_only();
         let mut inputs = Vec::new();
@@ -61,7 +61,7 @@ impl Wallet {
         })
     }
 
-    fn get_outpoints(amount: u64, fee: u64) -> Vec<Outpoint> {
+    fn get_outpoints() -> Vec<Outpoint> {
         // TODO: implement UTXO selection logic
         vec![Outpoint {
             tx_id: [0; 32],


### PR DESCRIPTION
Closes #26.

Every real lint fixed at the source — **no `#[allow(...)]` anywhere**, before or after. `cargo clippy --all-targets` now reports only dead-code, and the manifest is warning-free too.

| Location | Lint | Fix |
|---|---|---|
| `block.rs:88` | `precedence` | parentheses only — see below |
| `block.rs:94` | `len_zero` | `ids.is_empty()` |
| `block.rs:103`, `:112` | `assign_op_pattern` | `count -= 1` |
| `block.rs:111` | `implicit_saturating_sub` | `count.saturating_sub(1)` |
| `block.rs:120` | `partialeq_to_none` | `is_none()` |
| `block.rs:185` | `bool_assert_comparison` | `assert!(...)`, matching line 274 |
| `transaction.rs:34` | `needless_borrow` | dropped the `&` |
| `wallet.rs:64` ×2 | `unused_variables` | parameters **deleted** — see below |
| `Cargo.toml` | cargo, not clippy | `toml = "1.1.2"`; the `+spec-1.1.0` metadata was ignored and warned on every build |

## Two judgement calls

**`block.rs:88` is parentheses only.** Rust already binds `*` tighter than `<<`, so `target << exponent * 8` *already* computed `target << (exponent * 8)` — which is exactly the glossary's **n_bits** definition. The numbers are unchanged, and `block_generates_correct_hash` pins Bitcoin's real genesis hash `000000000019d668…` through `get_target_256` as proof. The `saturating_sub` rewrite is likewise provably identical on a `usize`.

**`wallet.rs`'s unused params were deleted, not underscore-prefixed.** `_amount` reads as "deliberately ignored" — a permanent-sounding claim about a function that is simply unwritten, and it silences an honest signal while looking like a fix. Deleting makes the signature true: the stub takes nothing and returns a fixed outpoint. The `// TODO` stays as the real marker, and the parameters return with whatever shape UTXO selection actually needs. This follows ADR-0011's own precedent — `sequence` and `lock_time` were deleted rather than pinned, because a field that doesn't exist needs no rule.

## The 13 dead-code warnings are left alone

`Block`, `Transaction`, `TxIn`, `Outpoint`, `TxOut`, `Wallet` and several `ByteReader` methods are never constructed. That is an accurate description of a domain model not yet wired to the network layer, and it resolves when M3 and M4 connect it. Silencing it would hide the one signal that says so. Count before and after: **13, unchanged**.

## Verified

107 tests, debug and release, no test modified. `cargo fmt --check` clean. `block.rs`'s mining and merkle tests are the guard that nothing behavioural moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtGvj56DSWHejm6XFDG4tc