### PR TITLE
Correct what ADR-0010 says the merkle code does

### DIFF
--- a/docs/adr/0010-merkle-construction.md
+++ b/docs/adr/0010-merkle-construction.md
@@ -1,6 +1,7 @@
 # ADR-0010 — Merkle construction
 
-- **Status:** Accepted
+- **Status:** Accepted — context corrected 2026-07-31, see
+  [Correction](#correction--the-existing-code-is-not-a-merkle-tree)
 - **Date:** 2026-07-30
 - **Deciders:** @matheusavi
 
@@ -14,12 +15,12 @@ directory. Three things were open:
    is what commits witnesses to the block header directly, and is why no coinbase
    witness commitment is needed. `block.rs:92` calls `get_tx_id()` and must call
    `get_wtxid()`.
-2. **Odd counts.** The implementation pairs the last node with itself, so `[a,b,c]`
-   and `[a,b,c,c]` produce the same root — CVE-2012-2459.
-3. **Pair ordering.** The implementation pops from the *end* of the vector, so it
-   concatenates `(last, second-to-last)`. Bitcoin concatenates left-to-right.
+2. **Odd counts.** Whatever replaces the current code must decide what happens to
+   an unpaired node.
+3. **Pair ordering.** Bitcoin concatenates left-to-right; the existing code does
+   not.
 
-The odd-count duplication is **block-level malleability** — structurally the same
+Odd-count duplication is **block-level malleability** — structurally the same
 problem ADR-0003 removed at the transaction level. Its payload is a denial of
 service: an attacker duplicates a transaction to produce an invalid block with the
 *same hash* as a legitimate one; a node that marks that hash permanently invalid
@@ -60,11 +61,47 @@ legitimate block sharing it is refused later. Bitcoin's patch is careful about
 exactly this, and rejecting without that care leaves the denial of service fully
 intact.
 
-## Consequences
+## Correction — the existing code is not a merkle tree
 
-- `get_merkle_root_hash` changes leaf source, pair order, and gains no complexity
-  otherwise; its existing tests are re-baselined, since every root it has ever
-  produced changes.
+*Added 2026-07-31. The decision below stands; the description of what it replaces
+was wrong, and the work is larger than this ADR implied.*
+
+This ADR was written believing the existing code built a tree with two defects:
+reversed pair order, and self-pairing on odd counts. It does not build a tree at
+all.
+
+`get_merkle_root_hash` pushes each hash back onto the same vector it is popping
+from, so results are consumed again within the same pass. For four leaves it
+produces:
+
+```
+H(H(H(d, c), b), a)          a right-leaning chain
+```
+
+where Bitcoin produces `H(H(a,b), H(c,d))`. Verified by transcribing the loop and
+comparing against a reference implementation: the two agree **only for a single
+transaction** — where the root is trivially the leaf — and differ at every count
+above one, by ordering at two and structurally from three upward.
+
+**Nothing caught this**, and that is the more useful half of the finding:
+
+- `prepare_for_mining` *requires* a merkle root rather than computing one, so
+  `block_generates_correct_hash` passes the fixture's hardcoded genesis root
+  straight through and never calls `get_merkle_root_hash`.
+- `mines_generates_correct_hash` does call it via `mine()`, but asserts only that
+  a nonce was found under the target — which **any** root satisfies.
+
+So the function has never had a test that pins its output. A known-answer test
+against a real block's merkle root would have failed on day one.
+
+**Consequence for the decision below:** Option B is still right, but it is not the
+one-line leaf change plus a pair-order fix described in the Consequences section.
+It is a replacement of the whole construction. The acceptance criteria live in the
+tracking issue.
+
+- `get_merkle_root_hash` is **rewritten**, not adjusted — see the Correction
+  above. It gains a known-answer test against a real block, which is the thing it
+  has never had.
 - Block validation gains one rule (duplicate wtxids) and one requirement on the
   *failure path* (do not poison the hash) — the latter being easy to implement and
   easy to forget, so it belongs in a test rather than only in prose.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -76,10 +76,10 @@ Bitcoin · 🅧 deferred out of v1 by [ADR-0001](adr/0001-v1-scope.md).
   program, opcodes cannot appear in it — "push-only" is the type, not a rule.
 - **Stack item** ✅ — one element of a Witness or of the VM's stack: an arbitrary
   byte string. Empty and zero are **false**; anything else is **true**.
-- **txid** ✅ (ADR-0003) — `HASH256` of the **witness-excluded** serialization.
-  Covers version, inputs (outpoint + sequence), outputs, and lock_time. This is
-  what an Outpoint references, what a mempool is keyed by, and what a spender
-  signs. Unmalleable: no witness byte can move it.
+- **txid** ✅ (ADR-0003, ADR-0011) — `HASH256` of the **witness-excluded**
+  serialization. Covers version, every input's outpoint and **coinbase_data**, and
+  every output. This is what an Outpoint references, what a mempool is keyed by,
+  and what a spender signs. Unmalleable: no witness byte can move it.
 - **wtxid** ✅ (ADR-0003) — `HASH256` of the **witness-included** serialization.
   Used only as the leaf of the block's merkle tree, which is how witnesses get
   committed by the header. Distinct from txid; the newtypes `Txid` and `Wtxid`
@@ -132,6 +132,11 @@ Bitcoin · 🅧 deferred out of v1 by [ADR-0001](adr/0001-v1-scope.md).
   counts. That duplication is not injective, so it is paired with a rule rejecting
   blocks that contain duplicate wtxids — and such a rejection must **not** cache
   the block hash as permanently invalid, or the denial of service survives.
+
+  ⚠️ **The code does not do this yet.** `Block::get_merkle_root_hash` currently
+  builds a right-leaning *chain*, not a tree — `H(H(H(d,c),b),a)` for four leaves
+  — and matches Bitcoin only for a single transaction. It has no test pinning its
+  output. See ADR-0010's Correction.
 - **Coinbase** ✅ (ADR-0008) — the block's first transaction, minting subsidy +
   fees. A `Transaction` identified by predicate: one input with a null outpoint.
   Its input carries an **empty Witness** and a `coinbase_data` beginning with the


### PR DESCRIPTION
Docs only. No code changes.

## ADR-0010 described something the code does not do

It said `get_merkle_root_hash` builds a tree with two defects — reversed pair order, self-pairing on odd counts — and framed the fix as changing the leaf type and the ordering.

**It is not a tree.** The function pushes each hash back onto the vector it is popping from, so results get consumed again within the same pass:

| leaves | avicoin | Bitcoin |
|---|---|---|
| 4 | `H(H(H(d,c),b),a)` — a right-leaning chain | `H(H(a,b),H(c,d))` |

Verified by transcribing the loop and comparing against a reference implementation. They agree **only for a single transaction** (where the root is trivially the leaf), differ by ordering at two, and differ structurally from three upward.

## Nothing caught it — which is the more useful half

- `prepare_for_mining` **requires** a merkle root rather than computing one, so `block_generates_correct_hash` passes the fixture's hardcoded genesis root straight through and never calls `get_merkle_root_hash`.
- `mines_generates_correct_hash` *does* call it via `mine()`, but asserts only that a nonce was found under target — which **any** root satisfies.

So the function has never had a test that pins its output. A known-answer test against a real block's merkle root would have failed on day one.

## What changed

- **ADR-0010** gains a `Correction` section. The decision stands — Bitcoin's algorithm plus the duplicate-wtxid rule — but its Consequences no longer claim this is a leaf swap plus a pair-order fix. It is a rewrite.
- **`docs/glossary.md`** — the Merkle root entry now warns that the code does not implement what the entry describes, so a reader doesn't take it as current.
- Also corrected the glossary's **txid** entry, which still listed `sequence` and `lock_time` as covered fields after ADR-0011 deleted them — contradicting the two entries directly above it.

The tracking issue carries the acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtGvj56DSWHejm6XFDG4tc