### PR TITLE
Give each connection a reader thread and a writer thread

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,10 +76,13 @@ CI (`.github/workflows/rust-tests.yml`) runs `cargo test` on pushes/PRs to `main
 
 ## Architecture
 
-The node is a small P2P server modeled on Bitcoin's message framing. `main.rs` binds the listener (so a bad address or a taken port fails the process, not a detached thread), then runs `protocol::listen` on one thread and dials each configured peer. Both inbound and outbound connections go through `protocol::spawn_connection`, which gives each its own thread — so the accept loop is never blocked, and one peer's failure is logged rather than taking the listener down. Each thread runs `handle_connection`, a blocking per-connection loop (`protocol.rs`) that:
-- sends a `Ping` every `PING_INTERVAL` (11s), first ping fires immediately,
-- reads with a 5s read timeout, appending bytes to a growing `recv_buffer`,
-- drains complete messages out of `recv_buffer` and replies to each (Ping → Pong).
+The node is a small P2P server modeled on Bitcoin's message framing. `main.rs` binds the listener (so a bad address or a taken port fails the process, not a detached thread), then runs `protocol::listen` on one thread and dials each configured peer. Both inbound and outbound connections go through `protocol::spawn_connection`, which gives each its own thread — so the accept loop is never blocked, and one peer's failure is logged rather than taking the listener down.
+
+Each connection then runs `handle_connection`, which splits into **two threads** over `try_clone()`d socket handles, joined by an `mpsc` channel of already-framed bytes:
+- the **reader** blocks in `read` with no timeout, appends to a growing `recv_buffer`, drains complete messages out of it, and *enqueues* replies (Ping → Pong) rather than writing them;
+- the **writer** owns every write. It drains the channel with `recv_timeout`, and that timeout *is* the ping timer — a `Ping` goes out every `PING_INTERVAL` (11s) whatever the reader is doing, first ping immediately. The interval is a parameter of `write_loop`, so tests use milliseconds.
+
+Nothing but the writer touches the socket for writing, which is what lets a future `PeerTable` hand a `Sender` to any thread. The two ends share a fate: the reader ending drops the channel, which ends the writer; the writer ending shuts the socket down, which unblocks the reader.
 
 **Message framing (`src/messages/`)** is the core of the wire protocol:
 - `Message<T>` = `Header` (24 bytes) + typed `payload: T`. The header is 4 magic bytes (`0xf9beb4d9`), a 12-byte command name, a 4-byte little-endian payload size, and a 4-byte checksum (first 4 bytes of the double-SHA256 of the payload).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,4 +116,6 @@ Design reasoning belongs in an [ADR](docs/adr/), behaviour in a test, and how-it
 
 Rust tests live inline as `#[cfg(test)] mod tests` at the bottom of each source file; there is no separate `tests/` directory. Parameterized cases use `rstest` (`#[rstest]` + `#[case(...)]`). Round-trip serialize→parse tests are the standard pattern for any new wire/serialization format.
 
-Prefer the highest existing seam over a new one. The connection path is tested through `std::io::Read`/`Write` with in-memory buffers rather than sockets (see `protocol.rs`'s `receive_ping_send_pong`), and pure logic like config layering is tested directly. Tests are written with the change they cover, not retrofitted.
+Prefer the highest existing seam over a new one. The connection path is tested through `std::io::Read`/`Write` and the outbound channel, with in-memory buffers rather than sockets — see `protocol.rs`'s `an_inbound_ping_is_answered_with_a_pong_on_the_outbound_channel`. Pure logic like config layering is tested directly. Tests are written with the change they cover, not retrofitted.
+
+A loopback `TcpListener` is fair game only where the socket wiring *is* the guarantee — that two threads share one connection, that a dropped write half wakes a parked reader. Reach for it when an in-memory seam would assert on a mock of the thing under test; not otherwise.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ struct Node {
     chain:   Blockchain,   // block index, best tip, height map, cumulative work
     utxo:    UtxoSet,      // Outpoint -> (value, locking commitment)
     mempool: Mempool,      // txid -> Transaction
-    peers:   PeerTable,    // peer_id -> PeerHandle { addr, tx: Sender<Message>, state }
+    peers:   PeerTable,    // peer_id -> PeerHandle { addr, tx: Sender<Vec<u8>>, state }
     wallet:  Wallet,
     config:  Config,
     log:     RingBuffer,   // in-memory log for the UI; mirrored to stdout in --headless
@@ -48,13 +48,24 @@ Per connection, **two threads**:
 
 - a **reader** — blocking `read` loop → append to buffer → drain complete
   messages → dispatch;
-- a **writer** — drains a `Receiver<Message>` into the socket, and drives the
+- a **writer** — drains a `Receiver<Vec<u8>>` into the socket, and drives the
   ping timer via `recv_timeout`.
+
+The channel carries **already-framed bytes**, not `Message<T>`: payload types
+differ per message, so a channel of `Message<T>` would need an enum of every
+message type, re-added at each new one. Serializing at the enqueue site also puts
+the failure where a caller can see it, and lets a future `broadcast()` frame once
+and hand the same bytes to every peer.
 
 `TcpStream::try_clone()` gives the two halves independent handles. Registering a
 peer stores its writer `Sender` in `PeerTable`; `broadcast()` locks the table and
 pushes to every peer's channel. A slow or dead peer therefore blocks only its own
 writer thread, never the node.
+
+The two threads share a fate. The reader ending drops the `Sender`, so the writer
+sees `Disconnected` and stops; the writer ending drops the write half, whose
+`Drop` shuts the socket down and wakes the reader out of a `read` that has no
+timeout. Neither can outlive the other.
 
 The miner is one more thread, holding no lock while it grinds: it snapshots the
 mempool, builds a candidate block, releases the lock, and only re-acquires it to

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,7 +91,7 @@ These hold everywhere and are not up for per-module negotiation:
 | `util.rs` | HASH256, compact-size | Built |
 | `config.rs` | Resolves configuration and validates addresses into `SocketAddr`; `resolve` is the canonical statement of precedence | Built |
 | `messages/` | `Header`, `Message<T>`, `Payload` trait, `MessageReceived` dispatch | Built (ping/pong) |
-| `protocol.rs` | Connection loop | Built — to be split into reader/writer |
+| `protocol.rs` | Per-connection reader and writer threads; the writer drives the ping timer | Built |
 | `block.rs` | Header assembly, merkle root over wtxids, target math, `mine()` | Built — merkle leaf and pair order change per ADR-0003/0010; not wired to the node |
 | `transaction.rs` | `Transaction` / `TxIn` / `TxOut` / `Outpoint` / `Witness`, dual serialization | Built — reshaped by ADR-0003/0008/0011 |
 | `wallet.rs` | Keypair, `TxBuilder`, signing | Stubbed — UTXO selection, balance, change are TODO |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -175,8 +175,8 @@ Bitcoin · 🅧 deferred out of v1 by [ADR-0001](adr/0001-v1-scope.md).
   `SocketAddr` at that boundary, so nothing downstream holds an address that
   might not parse. `config.rs::resolve` states the precedence rules and is the
   authority on them.
-- **SharedNode** ✅ — `Arc<Mutex<Node>>` central state. Designed, not yet built
-  (M1).
+- **SharedNode** ✅ — `Arc<Mutex<Node>>` central state, handed to every connection
+  thread. Built (M1); holds only `Config` so far.
 - **PeerTable / PeerHandle** ✅ — peer registry with a per-peer writer channel.
   Not yet built (M1).
 - **Ready peer** ✅ — a peer that has completed version/verack; only Ready peers

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,8 +3,8 @@ use crate::messages::message::{Message, MessageReceived};
 use crate::messages::ping::Ping;
 use crate::messages::pong::Pong;
 use crate::node::SharedNode;
-use anyhow::Result;
-use std::io::{Read, Write};
+use anyhow::{anyhow, Result};
+use std::io::{ErrorKind, Read, Write};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
 use std::sync::Arc;
@@ -47,42 +47,46 @@ fn spawn_connection(stream: TcpStream, node: SharedNode) {
     });
 }
 
+struct ShutdownOnDrop(TcpStream);
+
+impl Drop for ShutdownOnDrop {
+    fn drop(&mut self) {
+        // The reader parks in read() with no timeout; only a shutdown wakes it.
+        let _ = self.0.shutdown(Shutdown::Both);
+    }
+}
+
 fn handle_connection(stream: TcpStream, peer_addr: SocketAddr, node: SharedNode) -> Result<()> {
-    let write_half = stream.try_clone()?;
-    let (outbound, inbound) = mpsc::channel();
+    let write_half = ShutdownOnDrop(stream.try_clone()?);
+    let (outbound, queued) = mpsc::channel();
 
     let host_address = node.lock().expect("node lock poisoned").config.host_address;
     println!("{host_address} is handling a connection from {peer_addr}");
 
-    let writer = thread::spawn(move || {
-        if let Err(e) = write_loop(&write_half, inbound, PING_INTERVAL) {
-            println!("Writer for {peer_addr} stopped: {e:#}");
-        }
-        // Unblocks the reader, which is parked in read() with no timeout.
-        let _ = write_half.shutdown(Shutdown::Both);
-    });
+    let writer = thread::spawn(move || write_loop(&write_half.0, queued, PING_INTERVAL));
 
     let read_result = read_loop(stream, peer_addr, outbound);
-    let _ = writer.join();
 
-    read_result
+    match writer.join() {
+        Ok(write_result) => read_result.and(write_result),
+        Err(_) => Err(anyhow!("writer thread panicked")),
+    }
 }
 
 fn write_loop<W: Write>(
     mut writer: W,
-    inbound: Receiver<Vec<u8>>,
+    queued: Receiver<Vec<u8>>,
     ping_interval: Duration,
 ) -> Result<()> {
     let mut next_ping = Instant::now();
 
     loop {
-        let now = Instant::now();
-        if now >= next_ping {
+        if Instant::now() >= next_ping {
             writer.write_all(&Message::new(Ping::new())?.get_raw_format()?)?;
-            next_ping = now + ping_interval;
+            next_ping = Instant::now() + ping_interval;
         }
 
-        match inbound.recv_timeout(next_ping.saturating_duration_since(Instant::now())) {
+        match queued.recv_timeout(next_ping.saturating_duration_since(Instant::now())) {
             Ok(bytes) => writer.write_all(&bytes)?,
             Err(RecvTimeoutError::Timeout) => {}
             Err(RecvTimeoutError::Disconnected) => return Ok(()),
@@ -99,12 +103,14 @@ fn read_loop<R: Read>(
     let mut recv_buffer: Vec<u8> = Vec::new();
 
     loop {
-        match reader.read(&mut buffer)? {
-            0 => {
+        match reader.read(&mut buffer) {
+            Ok(0) => {
                 println!("Connection with {peer_addr} closed");
                 return Ok(());
             }
-            n => process_incoming_bytes(&outbound, &mut recv_buffer, &buffer[..n])?,
+            Ok(n) => process_incoming_bytes(&outbound, &mut recv_buffer, &buffer[..n])?,
+            Err(e) if e.kind() == ErrorKind::Interrupted => {}
+            Err(e) => return Err(e.into()),
         }
     }
 }
@@ -145,10 +151,14 @@ mod tests {
 
     const NEVER: Duration = Duration::from_secs(3600);
 
+    fn framed<P: crate::messages::message::Payload>(payload: P) -> Vec<u8> {
+        Message::new(payload).unwrap().get_raw_format().unwrap()
+    }
+
     fn framed_ping() -> (Vec<u8>, u64) {
         let ping = Ping::new();
         let nonce = ping.nonce;
-        (Message::new(ping).unwrap().get_raw_format().unwrap(), nonce)
+        (framed(ping), nonce)
     }
 
     fn parse_all(bytes: &[u8]) -> Vec<MessageReceived> {
@@ -166,11 +176,11 @@ mod tests {
 
     #[test]
     fn the_first_ping_is_written_without_waiting_for_the_interval() {
-        let (outbound, inbound) = mpsc::channel();
+        let (outbound, queued) = mpsc::channel();
         drop(outbound);
 
         let mut output = Vec::new();
-        write_loop(&mut output, inbound, NEVER).unwrap();
+        write_loop(&mut output, queued, NEVER).unwrap();
 
         assert!(
             matches!(parse_all(&output).as_slice(), [PingMessage(_)]),
@@ -180,20 +190,21 @@ mod tests {
 
     #[test]
     fn a_message_enqueued_from_another_thread_is_written_to_the_peer() {
-        let (outbound, inbound) = mpsc::channel();
+        let (outbound, queued) = mpsc::channel();
         let ping = Ping::new();
         let nonce = ping.nonce;
-        let pong = Message::new(Pong::new(ping).unwrap())
-            .unwrap()
-            .get_raw_format()
-            .unwrap();
+        let pong = framed(Pong::new(ping).unwrap());
 
-        thread::spawn(move || outbound.send(pong).unwrap())
-            .join()
-            .unwrap();
+        let sender = thread::spawn(move || {
+            // The writer must already be parked in recv_timeout, or this proves
+            // only that a drained queue is written, not that a live writer wakes.
+            thread::sleep(Duration::from_millis(50));
+            outbound.send(pong).unwrap();
+        });
 
         let mut output = Vec::new();
-        write_loop(&mut output, inbound, NEVER).unwrap();
+        write_loop(&mut output, queued, NEVER).unwrap();
+        sender.join().unwrap();
 
         match parse_all(&output).as_slice() {
             [PingMessage(_), PongMessage(pong)] => assert_eq!(nonce, pong.payload.nonce),
@@ -206,14 +217,14 @@ mod tests {
         let interval = Duration::from_millis(20);
         let run_for = Duration::from_millis(300);
 
-        let (outbound, inbound) = mpsc::channel::<Vec<u8>>();
+        let (outbound, queued) = mpsc::channel::<Vec<u8>>();
         let holder = thread::spawn(move || {
             thread::sleep(run_for);
             drop(outbound);
         });
 
         let mut output = Vec::new();
-        write_loop(&mut output, inbound, interval).unwrap();
+        write_loop(&mut output, queued, interval).unwrap();
         holder.join().unwrap();
 
         let pings = parse_all(&output).len();
@@ -232,7 +243,7 @@ mod tests {
 
     #[test]
     fn an_inbound_ping_is_answered_with_a_pong_on_the_outbound_channel() {
-        let (outbound, inbound) = mpsc::channel();
+        let (outbound, queued) = mpsc::channel();
         let mut recv_buffer = Vec::new();
         let (ping, nonce) = framed_ping();
 
@@ -240,17 +251,17 @@ mod tests {
 
         assert!(recv_buffer.is_empty(), "the ping should be fully consumed");
 
-        let queued = inbound.try_recv().expect("a ping must be answered");
-        match parse_all(&queued).as_slice() {
+        let reply = queued.try_recv().expect("a ping must be answered");
+        match parse_all(&reply).as_slice() {
             [PongMessage(pong)] => assert_eq!(nonce, pong.payload.nonce),
             other => panic!("expected a pong, got {other:?}"),
         }
-        assert!(inbound.try_recv().is_err(), "one ping, one pong");
+        assert!(queued.try_recv().is_err(), "one ping, one pong");
     }
 
     #[test]
     fn an_oversized_header_fails_the_connection_rather_than_being_awaited() {
-        let (outbound, inbound) = mpsc::channel();
+        let (outbound, queued) = mpsc::channel();
         let mut recv_buffer = Vec::new();
         let header = crate::messages::message::header_claiming(u32::MAX);
 
@@ -259,9 +270,46 @@ mod tests {
 
         assert!(format!("{error:#}").contains("too large"), "got: {error:#}");
         assert!(
-            inbound.try_recv().is_err(),
+            queued.try_recv().is_err(),
             "nothing should be queued in reply to a header that was refused"
         );
+    }
+
+    #[test]
+    fn an_interrupted_read_does_not_end_the_connection() {
+        struct InterruptsOnce {
+            ping: Vec<u8>,
+            interrupted: bool,
+        }
+
+        impl Read for InterruptsOnce {
+            fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+                if !self.interrupted {
+                    self.interrupted = true;
+                    return Err(std::io::Error::from(ErrorKind::Interrupted));
+                }
+                let taken = self.ping.len();
+                buffer[..taken].copy_from_slice(&self.ping);
+                self.ping.clear();
+                Ok(taken)
+            }
+        }
+
+        let (outbound, queued) = mpsc::channel();
+        let (ping, nonce) = framed_ping();
+        let reader = InterruptsOnce {
+            ping,
+            interrupted: false,
+        };
+
+        read_loop(reader, "127.0.0.1:1".parse().unwrap(), outbound)
+            .expect("a signal-interrupted read must be retried, not fail the connection");
+
+        let reply = queued.try_recv().expect("the ping after the interrupt");
+        match parse_all(&reply).as_slice() {
+            [PongMessage(pong)] => assert_eq!(nonce, pong.payload.nonce),
+            other => panic!("expected a pong, got {other:?}"),
+        }
     }
 
     fn next_message(stream: &mut TcpStream, buffer: &mut Vec<u8>) -> MessageReceived {
@@ -288,23 +336,23 @@ mod tests {
         let peer = TcpStream::connect(address).unwrap();
         peer.set_read_timeout(Some(Duration::from_secs(10)))
             .unwrap();
-        let (accepted, _) = listener.accept().unwrap();
+        let (accepted, peer_addr) = listener.accept().unwrap();
 
-        (peer, accepted, address)
+        (peer, accepted, peer_addr)
     }
 
-    fn a_node(address: SocketAddr) -> SharedNode {
+    fn a_node() -> SharedNode {
         Node::shared(Config {
-            host_address: address,
+            host_address: "127.0.0.1:34352".parse().unwrap(),
             addresses_to_connect: Vec::new(),
         })
     }
 
     #[test]
     fn a_connection_pings_its_peer_and_answers_the_peers_ping() {
-        let (mut peer, accepted, address) = a_connected_pair();
+        let (mut peer, accepted, peer_addr) = a_connected_pair();
 
-        thread::spawn(move || handle_connection(accepted, address, a_node(address)));
+        thread::spawn(move || handle_connection(accepted, peer_addr, a_node()));
 
         let mut buffer = Vec::new();
         assert!(
@@ -323,11 +371,11 @@ mod tests {
 
     #[test]
     fn both_threads_end_when_the_peer_disconnects() {
-        let (peer, accepted, address) = a_connected_pair();
+        let (peer, accepted, peer_addr) = a_connected_pair();
         let (done, finished) = mpsc::channel();
 
         thread::spawn(move || {
-            let _ = handle_connection(accepted, address, a_node(address));
+            let _ = handle_connection(accepted, peer_addr, a_node());
             done.send(()).unwrap();
         });
 
@@ -336,5 +384,32 @@ mod tests {
         finished
             .recv_timeout(Duration::from_secs(5))
             .expect("a connection whose peer is gone must not leave a thread parked");
+    }
+
+    #[test]
+    fn losing_the_write_half_wakes_a_reader_that_has_no_timeout() {
+        let (peer, accepted, _) = a_connected_pair();
+        let write_half = ShutdownOnDrop(accepted.try_clone().unwrap());
+        let mut read_half = accepted;
+        let (done, finished) = mpsc::channel();
+
+        thread::spawn(move || {
+            let mut buffer = [0u8; 16];
+            let _ = read_half.read(&mut buffer);
+            done.send(()).unwrap();
+        });
+
+        thread::sleep(Duration::from_millis(50));
+        assert!(
+            finished.try_recv().is_err(),
+            "the peer is silent but alive, so the reader must still be parked"
+        );
+
+        drop(write_half);
+
+        finished
+            .recv_timeout(Duration::from_secs(5))
+            .expect("dropping the write half must wake a reader parked in read()");
+        drop(peer);
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,9 +3,10 @@ use crate::messages::message::{Message, MessageReceived};
 use crate::messages::ping::Ping;
 use crate::messages::pong::Pong;
 use crate::node::SharedNode;
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use std::io::{Read, Write};
-use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -30,10 +31,6 @@ pub fn listen(listener: TcpListener, node: SharedNode) -> Result<()> {
     Ok(())
 }
 
-fn ping_is_due(last_ping: Option<Instant>, now: Instant, interval: Duration) -> bool {
-    last_ping.is_none_or(|sent| now.saturating_duration_since(sent) >= interval)
-}
-
 fn spawn_connection(stream: TcpStream, node: SharedNode) {
     thread::spawn(move || {
         let peer = match stream.peer_addr() {
@@ -50,48 +47,70 @@ fn spawn_connection(stream: TcpStream, node: SharedNode) {
     });
 }
 
-fn handle_connection(mut stream: TcpStream, peer_addr: SocketAddr, node: SharedNode) -> Result<()> {
-    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+fn handle_connection(stream: TcpStream, peer_addr: SocketAddr, node: SharedNode) -> Result<()> {
+    let write_half = stream.try_clone()?;
+    let (outbound, inbound) = mpsc::channel();
 
     let host_address = node.lock().expect("node lock poisoned").config.host_address;
     println!("{host_address} is handling a connection from {peer_addr}");
-    let mut buffer = [0u8; 4096];
-    let mut recv_buffer: Vec<u8> = Vec::new();
 
-    let mut last_ping: Option<Instant> = None;
+    let writer = thread::spawn(move || {
+        if let Err(e) = write_loop(&write_half, inbound, PING_INTERVAL) {
+            println!("Writer for {peer_addr} stopped: {e:#}");
+        }
+        // Unblocks the reader, which is parked in read() with no timeout.
+        let _ = write_half.shutdown(Shutdown::Both);
+    });
+
+    let read_result = read_loop(stream, peer_addr, outbound);
+    let _ = writer.join();
+
+    read_result
+}
+
+fn write_loop<W: Write>(
+    mut writer: W,
+    inbound: Receiver<Vec<u8>>,
+    ping_interval: Duration,
+) -> Result<()> {
+    let mut next_ping = Instant::now();
 
     loop {
-        if ping_is_due(last_ping, Instant::now(), PING_INTERVAL) {
-            let ping = Ping::new();
-            let message = Message::new(ping)?;
-            stream.write_all(&message.get_raw_format()?)?;
-            last_ping = Some(Instant::now());
+        let now = Instant::now();
+        if now >= next_ping {
+            writer.write_all(&Message::new(Ping::new())?.get_raw_format()?)?;
+            next_ping = now + ping_interval;
         }
 
-        match stream.read(&mut buffer) {
-            Ok(0) => {
-                println!("Connection with {peer_addr} closed");
-                return Ok(());
-            }
-            Ok(n) => {
-                println!("Received {n} bytes");
-                process_incoming_bytes(&mut stream, &mut recv_buffer, &buffer[..n])?
-            }
-            Err(e) => {
-                if e.kind() == std::io::ErrorKind::WouldBlock
-                    || e.kind() == std::io::ErrorKind::TimedOut
-                {
-                    println!("Connection timeout from {peer_addr}");
-                } else {
-                    return Err(anyhow!("Read error: {e}"));
-                }
-            }
+        match inbound.recv_timeout(next_ping.saturating_duration_since(Instant::now())) {
+            Ok(bytes) => writer.write_all(&bytes)?,
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => return Ok(()),
         }
     }
 }
 
-fn process_incoming_bytes<W: Write>(
-    writer: &mut W,
+fn read_loop<R: Read>(
+    mut reader: R,
+    peer_addr: SocketAddr,
+    outbound: Sender<Vec<u8>>,
+) -> Result<()> {
+    let mut buffer = [0u8; 4096];
+    let mut recv_buffer: Vec<u8> = Vec::new();
+
+    loop {
+        match reader.read(&mut buffer)? {
+            0 => {
+                println!("Connection with {peer_addr} closed");
+                return Ok(());
+            }
+            n => process_incoming_bytes(&outbound, &mut recv_buffer, &buffer[..n])?,
+        }
+    }
+}
+
+fn process_incoming_bytes(
+    outbound: &Sender<Vec<u8>>,
     recv_buffer: &mut Vec<u8>,
     buffer: &[u8],
 ) -> Result<()> {
@@ -99,18 +118,17 @@ fn process_incoming_bytes<W: Write>(
     while let (Some(message), bytes_consumed) = MessageReceived::try_parse_message(recv_buffer)? {
         recv_buffer.drain(0..bytes_consumed);
 
-        handle_messages(writer, message)?
+        handle_messages(outbound, message)?
     }
     Ok(())
 }
 
-fn handle_messages<W: Write>(writer: &mut W, message: MessageReceived) -> Result<()> {
+fn handle_messages(outbound: &Sender<Vec<u8>>, message: MessageReceived) -> Result<()> {
     match message {
         PingMessage(ping) => {
             println!("Ping received {:?}", ping);
             let pong = Pong::new(ping.payload)?;
-            let message = Message::new(pong)?;
-            writer.write_all(&message.get_raw_format()?)?;
+            outbound.send(Message::new(pong)?.get_raw_format()?)?;
         }
         PongMessage(pong) => {
             println!("Pong received {:?}", pong)
@@ -122,73 +140,201 @@ fn handle_messages<W: Write>(writer: &mut W, message: MessageReceived) -> Result
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rstest::rstest;
+    use crate::config::Config;
+    use crate::node::Node;
 
-    #[test]
-    fn the_first_ping_is_due_immediately() {
-        assert!(
-            ping_is_due(None, Instant::now(), PING_INTERVAL),
-            "a connection that has never pinged should ping at once"
-        );
-    }
+    const NEVER: Duration = Duration::from_secs(3600);
 
-    #[rstest]
-    #[case::just_sent(0, false)]
-    #[case::one_second_short(10, false)]
-    #[case::exactly_at_the_interval(11, true)]
-    #[case::well_past(60, true)]
-    fn a_ping_is_due_once_the_interval_has_elapsed(
-        #[case] seconds_since_last: u64,
-        #[case] expected: bool,
-    ) {
-        let sent = Instant::now();
-        let now = sent + Duration::from_secs(seconds_since_last);
-
-        assert_eq!(
-            expected,
-            ping_is_due(Some(sent), now, PING_INTERVAL),
-            "{seconds_since_last}s after a ping, with an interval of {PING_INTERVAL:?}"
-        );
-    }
-
-    #[test]
-    fn an_oversized_header_fails_the_connection_rather_than_being_awaited() {
-        let mut output = Vec::new();
-        let mut recv_buffer = Vec::new();
-        let header = crate::messages::message::header_claiming(u32::MAX);
-
-        let error = process_incoming_bytes(&mut output, &mut recv_buffer, &header)
-            .expect_err("a header claiming 4 GB must fail the connection, not be waited on");
-
-        assert!(format!("{error:#}").contains("too large"), "got: {error:#}");
-        assert!(
-            output.is_empty(),
-            "nothing should be sent in reply to a header that was refused"
-        );
-    }
-
-    #[test]
-    fn receive_ping_send_pong() {
-        let mut output = Vec::new();
-        let mut recv_buffer = Vec::new();
-
+    fn framed_ping() -> (Vec<u8>, u64) {
         let ping = Ping::new();
-        let payload_received = Message::new(ping.clone())
+        let nonce = ping.nonce;
+        (Message::new(ping).unwrap().get_raw_format().unwrap(), nonce)
+    }
+
+    fn parse_all(bytes: &[u8]) -> Vec<MessageReceived> {
+        let mut rest = bytes;
+        let mut messages = Vec::new();
+
+        while let (Some(message), consumed) = MessageReceived::try_parse_message(rest).unwrap() {
+            messages.push(message);
+            rest = &rest[consumed..];
+        }
+
+        assert!(rest.is_empty(), "{} trailing bytes", rest.len());
+        messages
+    }
+
+    #[test]
+    fn the_first_ping_is_written_without_waiting_for_the_interval() {
+        let (outbound, inbound) = mpsc::channel();
+        drop(outbound);
+
+        let mut output = Vec::new();
+        write_loop(&mut output, inbound, NEVER).unwrap();
+
+        assert!(
+            matches!(parse_all(&output).as_slice(), [PingMessage(_)]),
+            "a new connection should ping at once, not after an hour"
+        );
+    }
+
+    #[test]
+    fn a_message_enqueued_from_another_thread_is_written_to_the_peer() {
+        let (outbound, inbound) = mpsc::channel();
+        let ping = Ping::new();
+        let nonce = ping.nonce;
+        let pong = Message::new(Pong::new(ping).unwrap())
             .unwrap()
             .get_raw_format()
             .unwrap();
 
-        process_incoming_bytes(&mut output, &mut recv_buffer, &payload_received).unwrap();
+        thread::spawn(move || outbound.send(pong).unwrap())
+            .join()
+            .unwrap();
 
-        let (response, bytes_read) = MessageReceived::try_parse_message(&output).unwrap();
+        let mut output = Vec::new();
+        write_loop(&mut output, inbound, NEVER).unwrap();
 
-        assert_eq!(payload_received.len(), bytes_read);
-
-        assert_eq!(0, recv_buffer.len());
-
-        match response {
-            Some(PongMessage(pong)) => assert_eq!(ping.nonce, pong.payload.nonce),
-            other => panic!("Expected pong message, got {:?}", other),
+        match parse_all(&output).as_slice() {
+            [PingMessage(_), PongMessage(pong)] => assert_eq!(nonce, pong.payload.nonce),
+            other => panic!("expected the opening ping then the enqueued pong, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn pings_recur_at_the_configured_interval() {
+        let interval = Duration::from_millis(20);
+        let run_for = Duration::from_millis(300);
+
+        let (outbound, inbound) = mpsc::channel::<Vec<u8>>();
+        let holder = thread::spawn(move || {
+            thread::sleep(run_for);
+            drop(outbound);
+        });
+
+        let mut output = Vec::new();
+        write_loop(&mut output, inbound, interval).unwrap();
+        holder.join().unwrap();
+
+        let pings = parse_all(&output).len();
+        let expected = run_for.as_millis() / interval.as_millis();
+
+        assert!(
+            pings >= 5,
+            "{pings} pings in {run_for:?} at a {interval:?} interval; \
+             a timer that only fires when something else wakes it would send ~1, not ~{expected}"
+        );
+        assert!(
+            pings <= 40,
+            "{pings} pings is a busy loop, not a {interval:?} interval"
+        );
+    }
+
+    #[test]
+    fn an_inbound_ping_is_answered_with_a_pong_on_the_outbound_channel() {
+        let (outbound, inbound) = mpsc::channel();
+        let mut recv_buffer = Vec::new();
+        let (ping, nonce) = framed_ping();
+
+        process_incoming_bytes(&outbound, &mut recv_buffer, &ping).unwrap();
+
+        assert!(recv_buffer.is_empty(), "the ping should be fully consumed");
+
+        let queued = inbound.try_recv().expect("a ping must be answered");
+        match parse_all(&queued).as_slice() {
+            [PongMessage(pong)] => assert_eq!(nonce, pong.payload.nonce),
+            other => panic!("expected a pong, got {other:?}"),
+        }
+        assert!(inbound.try_recv().is_err(), "one ping, one pong");
+    }
+
+    #[test]
+    fn an_oversized_header_fails_the_connection_rather_than_being_awaited() {
+        let (outbound, inbound) = mpsc::channel();
+        let mut recv_buffer = Vec::new();
+        let header = crate::messages::message::header_claiming(u32::MAX);
+
+        let error = process_incoming_bytes(&outbound, &mut recv_buffer, &header)
+            .expect_err("a header claiming 4 GB must fail the connection, not be waited on");
+
+        assert!(format!("{error:#}").contains("too large"), "got: {error:#}");
+        assert!(
+            inbound.try_recv().is_err(),
+            "nothing should be queued in reply to a header that was refused"
+        );
+    }
+
+    fn next_message(stream: &mut TcpStream, buffer: &mut Vec<u8>) -> MessageReceived {
+        let mut chunk = [0u8; 512];
+
+        loop {
+            if let (Some(message), consumed) = MessageReceived::try_parse_message(buffer)
+                .expect("peer sent an unparseable message")
+            {
+                buffer.drain(0..consumed);
+                return message;
+            }
+
+            let read = stream.read(&mut chunk).expect("peer went quiet");
+            assert_ne!(0, read, "peer closed before sending the expected message");
+            buffer.extend_from_slice(&chunk[..read]);
+        }
+    }
+
+    fn a_connected_pair() -> (TcpStream, TcpStream, SocketAddr) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let peer = TcpStream::connect(address).unwrap();
+        peer.set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let (accepted, _) = listener.accept().unwrap();
+
+        (peer, accepted, address)
+    }
+
+    fn a_node(address: SocketAddr) -> SharedNode {
+        Node::shared(Config {
+            host_address: address,
+            addresses_to_connect: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn a_connection_pings_its_peer_and_answers_the_peers_ping() {
+        let (mut peer, accepted, address) = a_connected_pair();
+
+        thread::spawn(move || handle_connection(accepted, address, a_node(address)));
+
+        let mut buffer = Vec::new();
+        assert!(
+            matches!(next_message(&mut peer, &mut buffer), PingMessage(_)),
+            "a connection should open by pinging its peer"
+        );
+
+        let (ping, nonce) = framed_ping();
+        peer.write_all(&ping).unwrap();
+
+        match next_message(&mut peer, &mut buffer) {
+            PongMessage(pong) => assert_eq!(nonce, pong.payload.nonce),
+            other => panic!("expected a pong for our ping, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn both_threads_end_when_the_peer_disconnects() {
+        let (peer, accepted, address) = a_connected_pair();
+        let (done, finished) = mpsc::channel();
+
+        thread::spawn(move || {
+            let _ = handle_connection(accepted, address, a_node(address));
+            done.send(()).unwrap();
+        });
+
+        drop(peer);
+
+        finished
+            .recv_timeout(Duration::from_secs(5))
+            .expect("a connection whose peer is gone must not leave a thread parked");
     }
 }


### PR DESCRIPTION
Closes #15.

## The bug behind the ticket

`PING_INTERVAL` was 11s. Two real nodes pinged every **15s**. The ping check ran once per read-loop iteration and the loop was gated by the 5s read timeout, so a ping could only fire on a 5s boundary — and 11 rounds up to 15. The constant did not describe the node.

Moving the timer onto the writer's `recv_timeout` fixes that, and is the shape M1 needs anyway: the writer owns every write, so any thread can reach a peer by enqueueing on its channel. That is the milestone's headline guarantee.

Measured on loopback, before and after:

| | gaps |
|---|---|
| `main` | 15.2s, 14.8s |
| this branch | 11.6s, 11.0s, 11.0s |

## Shape

The reader now blocks in `read` with **no timeout at all** — the timeout's only job was to let the ping check run. It never detected a dead peer; the old arm printed `Connection timeout` and looped. Nothing was lost by deleting it, and peer liveness is M2's `Ready peer` work.

The channel carries **already-framed bytes**, not `Message<T>`: payload types differ per message, so a channel of `Message<T>` would need an enum re-extended at every new message type. `ARCHITECTURE.md` said `Sender<Message>` and is corrected.

The two threads share a fate, in both directions:
- reader ends → drops the `Sender` → writer sees `Disconnected` → stops;
- writer ends → drops the write half → its `Drop` shuts the socket down → reader wakes.

`Drop` rather than a line at the end of the closure, so it also runs when the writer unwinds. Without that, a writer panic left the reader parked forever and leaked the connection thread.

## Tests

Nine, all killing at least one mutation — each was verified by reverting the production change and confirming which tests go red:

| revert | caught by |
|---|---|
| interval hardcoded (the original bug) | `pings_recur_at_the_configured_interval` |
| deadline never advances (busy loop) | same, upper bound |
| writer discards what it is handed | `a_message_enqueued_from_another_thread_…` |
| ping not answered | `an_inbound_ping_is_answered_…` |
| a stray `Sender` keeps the writer alive | `both_threads_end_when_the_peer_disconnects` |
| `Drop` no longer shuts the socket down | `losing_the_write_half_wakes_a_reader_…` |
| EINTR kills the connection | `an_interrupted_read_does_not_end_the_connection` |
| first ping waits out the interval | `the_first_ping_is_written_without_waiting_…` |

The enqueue test sleeps before sending so the writer is already parked in `recv_timeout` — otherwise it proves only that a drained queue gets written, not that a live writer wakes.

Loopback sockets appear in three tests, where the socket wiring *is* the guarantee. `CLAUDE.md`'s testing conventions now say when that's fair game, instead of claiming the connection path never uses sockets.

The timing test ran 25× clean.

## Review

`/code-review` found two doc contradictions and three real defects — a skipped shutdown on panic, a write-error death reporting `Ok`, and EINTR killing the connection. All fixed in 8031258.

**Left for #16:** the outbound channel is unbounded, so a stalled peer grows its queue without limit. That only starts to matter once `broadcast()` can push to every peer at once; added to that ticket.

## Not done, deliberately

The interval is injectable into `write_loop`, which is where the timer lives and where tests set milliseconds. Threading it through `handle_connection` → `spawn_connection` → `listen`/`connect` would plumb an unused parameter through four functions for no caller.