### PR TITLE
Build the node before every functional run, not only when missing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ python3 -m venv .venv && .venv/bin/pip install -r requirements.txt   # once
 AVICOIN_BIN=/path/to/avicoin .venv/bin/python -m pytest test/functional
 ```
 
-It builds the debug binary if one is missing. With `direnv` installed, `.envrc` activates the venv and plain `pytest test/functional` works.
+It runs `cargo build` first, every time, unless `AVICOIN_BIN` says otherwise — "build only if missing" once let a `cargo clippy` run leave a stale binary behind, and the suite silently tested code that was not the code under test. With `direnv` installed, `.envrc` activates the venv and plain `pytest test/functional` works.
 
 CI (`.github/workflows/tests.yml`) runs both suites on pushes/PRs to `main`, as two jobs: **Unit tests** (`cargo test`) and **Functional tests** (`pytest`). Both must pass. `cargo test` alone does **not** cover the functional suite — that is the whole reason the CI job exists, and why it shipped with the tests rather than after them.
 

--- a/test/functional/framework/node.py
+++ b/test/functional/framework/node.py
@@ -1,7 +1,7 @@
 """Launching the real binary, and reading what it says.
 
 Set AVICOIN_BIN to test a binary built elsewhere; otherwise the debug build is
-used, and built if missing.
+rebuilt and used.
 """
 
 import os
@@ -10,6 +10,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from functools import cache
 from pathlib import Path
 from typing import List, Optional
 
@@ -19,6 +20,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_BINARY = REPO_ROOT / "target" / "debug" / "avicoin"
 
 
+@cache
 def binary_path() -> Path:
     override = os.environ.get("AVICOIN_BIN")
     if override:
@@ -27,13 +29,16 @@ def binary_path() -> Path:
             raise FileNotFoundError(f"AVICOIN_BIN={override} does not exist")
         return path
 
-    if not DEFAULT_BINARY.exists():
-        if shutil.which("cargo") is None:
-            raise RuntimeError(
-                "cargo is not on PATH and the binary is not built; "
-                "build it first or set AVICOIN_BIN"
-            )
-        subprocess.run(["cargo", "build", "--quiet"], cwd=REPO_ROOT, check=True)
+    if shutil.which("cargo") is None:
+        raise RuntimeError(
+            "cargo is not on PATH; build the node first and set AVICOIN_BIN"
+        )
+
+    # Always build, never "build if missing". An existing binary may predate the
+    # change under test -- `cargo clippy` alone leaves a stale one behind -- and a
+    # suite that silently tests the wrong binary is the failure this whole
+    # arrangement exists to prevent. Cargo is a no-op when it is already current.
+    subprocess.run(["cargo", "build", "--quiet"], cwd=REPO_ROOT, check=True)
 
     if not DEFAULT_BINARY.exists():
         raise RuntimeError(f"no binary at {DEFAULT_BINARY} after cargo build")


### PR DESCRIPTION
`framework/node.py` ran `cargo build` only when `target/debug/avicoin` was **absent**, so an existing binary was used however stale.

This bit me while working on #16. `cargo clippy --all-targets` type-checks and lints but doesn't emit the binary, so after a clippy run the source had moved and the binary hadn't. The functional suite then reported **4 failures** that looked exactly like a regression in the change under review — and were entirely an artefact of testing the previous binary.

That is precisely the failure [ADR-0014](https://github.com/matheusavi/avicoin/blob/main/docs/adr/0014-functional-test-suite.md) exists to prevent: a suite in a second toolchain that silently stops matching the binary. The old Python suite died of the same disease in a slower form — `--listen` was renamed under it and nothing noticed.

Now it always builds, `@cache`d so the cost is paid once per pytest process. Cargo is a no-op when already current.

Verified by reproducing the original trap:

```
$ touch src/node.rs && cargo clippy --all-targets   # binary now older than source
binary  1785511451
source  1785511555
$ pytest test/functional -q
22 passed
binary  1785511556                                   # rebuilt before running
```

`AVICOIN_BIN` still bypasses the build for a binary produced elsewhere, which is how CI uses it.

Split out of the #16 branch — `/code-review` flagged it as unrelated scope in that change, correctly.