### PR TITLE
Give the node a peer table it can reach every peer through

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,11 +89,15 @@ CI (`.github/workflows/tests.yml`) runs both suites on pushes/PRs to `main`, as 
 
 The node is a small P2P server modeled on Bitcoin's message framing. `main.rs` binds the listener (so a bad address or a taken port fails the process, not a detached thread), then runs `protocol::listen` on one thread and dials each configured peer. Both inbound and outbound connections go through `protocol::spawn_connection`, which gives each its own thread — so the accept loop is never blocked, and one peer's failure is logged rather than taking the listener down.
 
-Each connection then runs `handle_connection`, which splits into **two threads** over `try_clone()`d socket handles, joined by an `mpsc` channel of already-framed bytes:
+`spawn_connection` registers the peer in `node.peers` before handing off, and a `Registered` guard removes it on any exit including a panic. A refused connection (`MAX_PEERS`, or an address already dialled) is dropped there and never becomes a thread pair.
+
+Each connection then runs `handle_connection`, which splits into **two threads** over `try_clone()`d socket handles, joined by a *bounded* `sync_channel` of already-framed bytes:
 - the **reader** blocks in `read` with no timeout, appends to a growing `recv_buffer`, drains complete messages out of it, and *enqueues* replies (Ping → Pong) rather than writing them;
 - the **writer** owns every write. It drains the channel with `recv_timeout`, and that timeout *is* the ping timer — a `Ping` goes out every `PING_INTERVAL` (11s) whatever the reader is doing, first ping immediately. The interval is a parameter of `write_loop`, so tests use milliseconds.
 
-Nothing but the writer touches the socket for writing, which is what lets a future `PeerTable` hand a `Sender` to any thread. The two ends share a fate: the reader ending drops the channel, which ends the writer; the writer ending shuts the socket down, which unblocks the reader.
+**The peer table holds each peer's only sender**, and the reader enqueues through it (`Registered::deliver`) rather than keeping a clone. That is deliberate and load-bearing: removing a peer drops the last sender, so the writer sees `Disconnected`, its shutdown wakes the reader, and the connection ends. A clone anywhere else turns "drop this peer" into bookkeeping while the threads and the peer's 32 MiB `recv_buffer` carry on outside the table meant to bound them.
+
+The two ends share a fate: the reader ending releases the registration — **before** the join, or the table's sender keeps the writer alive — and the writer ending shuts the socket down, which unblocks the reader.
 
 **Message framing (`src/messages/`)** is the core of the wire protocol:
 - `Message<T>` = `Header` (24 bytes) + typed `payload: T`. The header is 4 magic bytes (`0xf9beb4d9`), a 12-byte command name, a 4-byte little-endian payload size, and a 4-byte checksum (first 4 bytes of the double-SHA256 of the payload).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ struct Node {
     chain:   Blockchain,   // block index, best tip, height map, cumulative work
     utxo:    UtxoSet,      // Outpoint -> (value, locking commitment)
     mempool: Mempool,      // txid -> Transaction
-    peers:   PeerTable,    // peer_id -> PeerHandle { addr, tx: Sender<Vec<u8>>, state }
+    peers:   PeerTable,    // PeerId -> PeerHandle { address, origin, tx: SyncSender<Vec<u8>> }
     wallet:  Wallet,
     config:  Config,
     log:     RingBuffer,   // in-memory log for the UI; mirrored to stdout in --headless
@@ -57,15 +57,36 @@ message type, re-added at each new one. Serializing at the enqueue site also put
 the failure where a caller can see it, and lets a future `broadcast()` frame once
 and hand the same bytes to every peer.
 
-`TcpStream::try_clone()` gives the two halves independent handles. Registering a
-peer stores its writer `Sender` in `PeerTable`; `broadcast()` locks the table and
-pushes to every peer's channel. A slow or dead peer therefore blocks only its own
-writer thread, never the node.
+`TcpStream::try_clone()` gives the two halves independent handles.
+`spawn_connection` registers the peer — one place, so dialling and accepting
+cannot drift — and a guard removes it on any exit, including a panic.
+`broadcast()` locks the table and pushes to every peer's channel.
 
-The two threads share a fate. The reader ending drops the `Sender`, so the writer
-sees `Disconnected` and stops; the writer ending drops the write half, whose
-`Drop` shuts the socket down and wakes the reader out of a `read` that has no
-timeout. Neither can outlive the other.
+The table holds each peer's **only** sender, and that is load-bearing: removing
+the entry drops the last sender, the writer sees the disconnect, and its shutdown
+wakes the reader. So dropping a peer ends its connection rather than leaving two
+threads and a 32 MiB `recv_buffer` running outside the table meant to bound them.
+The reader therefore sends through the table rather than holding a clone.
+
+Delivery is `try_send`, never a blocking send: one stalled socket must not hold
+the node's lock and stop delivery to everyone else. A peer whose queue is full
+past `OUTBOUND_QUEUE` (128 messages) is **dropped**, not buffered.
+
+**`MAX_PEERS` is 32, and the policy at the cap is to refuse the newcomer** rather
+than evict an established peer — there is no peer scoring to evict on yet. The
+cap exists because each connection may legally hold `MAX_PAYLOAD_SIZE` in its
+`recv_buffer`, so the exposure is `peers × 32 MiB`; this bounds the multiplier
+without making it small, and lowering the per-connection ceiling is separate
+work. Inbound and outbound share the cap, so a flood of inbound connections can
+crowd out configured dials — acceptable while peers come from a static list, not
+once discovery lands in M2.
+
+The two threads share a fate, in both directions. The reader ending releases the
+registration — before joining the writer, or the sender it holds would keep the
+writer alive forever — so the writer sees `Disconnected` and stops. The writer
+ending drops the write half, whose `Drop` shuts the socket down and wakes the
+reader out of a `read` that has no timeout. Neither can outlive the other, and
+neither can outlive its entry in the table.
 
 The miner is one more thread, holding no lock while it grinds: it snapshots the
 mempool, builds a candidate block, releases the lock, and only re-acquires it to
@@ -109,7 +130,7 @@ These hold everywhere and are not up for per-module negotiation:
 | `block_storage.rs` | `blocks.dat` / `undo.dat` framing and offset reads | Empty stub (ADR-0013) |
 | `script.rs` | Opcodes, stack, interpreter, resource limits | Not built (ADR-0002) |
 | `address.rs` | Base58Check — display edge only | Not built (ADR-0005) |
-| `node.rs` | `Node` / `SharedNode`, peer registry, broadcast | Not built |
+| `node.rs` | `Node` / `SharedNode`, `PeerTable`, `send_to` / `broadcast` | Built — nothing broadcasts until relay lands in M3 |
 | `blockchain.rs` | Block index, cumulative work, multiple tips, connect/disconnect, reorg | Not built (ADR-0012) |
 | `difficulty.rs` | Per-block retarget, timestamp rules | Not built (ADR-0009) |
 | `utxo.rs` | `Outpoint` → output set, backed by the KV store | Not built |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -72,6 +72,19 @@ Delivery is `try_send`, never a blocking send: one stalled socket must not hold
 the node's lock and stop delivery to everyone else. A peer whose queue is full
 past `OUTBOUND_QUEUE` (128 messages) is **dropped**, not buffered.
 
+Dropping it is not on its own enough to end the connection, and the reason is
+worth knowing: `mpsc` hands the writer every *buffered* message before it ever
+reports `Disconnected`, so a writer whose queue was full goes on writing to the
+socket that stalled. The write half therefore carries a **30s write timeout**.
+That, not the table, is what guarantees a peer which stopped reading eventually
+loses its connection — with or without anything evicting it. Teardown is bounded
+by that timeout rather than immediate, so a peer can briefly outlive its table
+entry.
+
+`OUTBOUND_QUEUE` bounds **messages, not bytes**. Today every queued message is a
+32-byte pong, so it is a memory bound in practice; once blocks and transactions
+are relayed it stops being one, and the queue will need a byte budget instead.
+
 **`MAX_PEERS` is 32, and the policy at the cap is to refuse the newcomer** rather
 than evict an established peer — there is no peer scoring to evict on yet. The
 cap exists because each connection may legally hold `MAX_PAYLOAD_SIZE` in its

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -176,9 +176,20 @@ Bitcoin · 🅧 deferred out of v1 by [ADR-0001](adr/0001-v1-scope.md).
   might not parse. `config.rs::resolve` states the precedence rules and is the
   authority on them.
 - **SharedNode** ✅ — `Arc<Mutex<Node>>` central state, handed to every connection
-  thread. Built (M1); holds only `Config` so far.
-- **PeerTable / PeerHandle** ✅ — peer registry with a per-peer writer channel.
-  Not yet built (M1).
+  thread. Built (M1); holds `Config` and the `PeerTable` so far.
+- **PeerTable / PeerHandle** ✅ — the peer registry: `PeerId` → `PeerHandle`
+  (`address`, `origin`, and the peer's **only** outbound sender). Built (M1).
+  Holding the only sender is what makes removal a disconnect rather than
+  bookkeeping — see [ARCHITECTURE](ARCHITECTURE.md#concurrency-model).
+- **PeerId** ✅ — a peer's identity *within one node's run*, assigned on
+  registration. Not derived from an address, and not stable across restarts or
+  between nodes; it is a table key, never anything on the wire.
+- **Origin** ✅ — whether we **dialled** a peer or **accepted** it. Dedup is on
+  dialled addresses only: an accepted connection shows an ephemeral source port,
+  so the same peer looks like two until M2's version nonce identifies it.
+- **MAX_PEERS / OUTBOUND_QUEUE** ✅ — 32 connections, 128 queued messages each.
+  At either limit the peer is **refused** or **dropped**, never made to wait: a
+  blocking send would stall the whole node on one slow socket.
 - **Ready peer** ✅ — a peer that has completed version/verack; only Ready peers
   are relayed to. Not yet built (M2).
 - **Reorg** ✅ (ADR-0012) — switching to a heavier branch. Disconnect back to the

--- a/src/node.rs
+++ b/src/node.rs
@@ -4,13 +4,7 @@ use std::net::SocketAddr;
 use std::sync::mpsc::{SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 
-/// Every connection owns a `recv_buffer` that a peer may legally hold at
-/// `MAX_PAYLOAD_SIZE`, so the node's exposure is this many times 32 MiB.
-/// Lowering the per-connection ceiling is what would make that small; this only
-/// stops the multiplier being chosen by whoever dials us.
 pub const MAX_PEERS: usize = 32;
-
-/// Messages queued for one peer before it is considered unable to keep up.
 pub const OUTBOUND_QUEUE: usize = 128;
 
 pub type PeerId = u64;
@@ -88,11 +82,10 @@ impl PeerTable {
         self.peers.is_empty()
     }
 
-    pub fn addresses(&self) -> Vec<SocketAddr> {
-        self.peers.values().map(|peer| peer.address).collect()
+    pub fn ids(&self) -> Vec<PeerId> {
+        self.peers.keys().copied().collect()
     }
 
-    /// Delivers to one peer, dropping it if it cannot take the message.
     pub fn send_to(&mut self, id: PeerId, message: Vec<u8>) -> bool {
         let Some(peer) = self.peers.get(&id) else {
             return false;
@@ -107,11 +100,8 @@ impl PeerTable {
         }
     }
 
-    /// Delivers to every peer, dropping those that cannot take the message.
-    ///
-    /// `try_send` rather than `send`: a blocking send would let one stalled
-    /// socket hold the node's lock and stop delivery to everyone else, which is
-    /// the whole reason the writer thread exists.
+    /// `try_send`, because a blocking send would hold the node's lock on one
+    /// stalled socket and stop delivery to everyone else.
     pub fn broadcast(&mut self, message: &[u8]) -> usize {
         let mut delivered = 0;
         let mut failed = Vec::new();
@@ -203,7 +193,7 @@ mod tests {
 
         let (id, _queued) = a_peer(&mut table, 5000);
         assert_eq!(1, table.len());
-        assert_eq!(vec![address(5000)], table.addresses());
+        assert_eq!(vec![id], table.ids());
 
         assert!(table.remove(id).is_some());
         assert!(
@@ -211,6 +201,7 @@ mod tests {
             "closing a connection must remove its peer"
         );
         assert!(table.remove(id).is_none(), "removing twice is not a peer");
+        assert!(table.ids().is_empty());
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,22 +1,155 @@
 use crate::config::Config;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::mpsc::{SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 
+/// Every connection owns a `recv_buffer` that a peer may legally hold at
+/// `MAX_PAYLOAD_SIZE`, so the node's exposure is this many times 32 MiB.
+/// Lowering the per-connection ceiling is what would make that small; this only
+/// stops the multiplier being chosen by whoever dials us.
+pub const MAX_PEERS: usize = 32;
+
+/// Messages queued for one peer before it is considered unable to keep up.
+pub const OUTBOUND_QUEUE: usize = 128;
+
+pub type PeerId = u64;
 pub type SharedNode = Arc<Mutex<Node>>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Origin {
+    Dialled,
+    Accepted,
+}
+
+#[derive(Debug)]
+pub struct PeerHandle {
+    pub address: SocketAddr,
+    pub origin: Origin,
+    outbound: SyncSender<Vec<u8>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Refused {
+    AtCapacity,
+    AlreadyDialled,
+}
+
+#[derive(Debug, Default)]
+pub struct PeerTable {
+    peers: HashMap<PeerId, PeerHandle>,
+    next_id: PeerId,
+}
+
+impl PeerTable {
+    pub fn register(
+        &mut self,
+        address: SocketAddr,
+        origin: Origin,
+        outbound: SyncSender<Vec<u8>>,
+    ) -> Result<PeerId, Refused> {
+        if origin == Origin::Dialled && self.dialled(address) {
+            return Err(Refused::AlreadyDialled);
+        }
+
+        if self.peers.len() >= MAX_PEERS {
+            return Err(Refused::AtCapacity);
+        }
+
+        let id = self.next_id;
+        self.next_id += 1;
+        self.peers.insert(
+            id,
+            PeerHandle {
+                address,
+                origin,
+                outbound,
+            },
+        );
+
+        Ok(id)
+    }
+
+    fn dialled(&self, address: SocketAddr) -> bool {
+        self.peers
+            .values()
+            .any(|peer| peer.origin == Origin::Dialled && peer.address == address)
+    }
+
+    pub fn remove(&mut self, id: PeerId) -> Option<PeerHandle> {
+        self.peers.remove(&id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.peers.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.peers.is_empty()
+    }
+
+    pub fn addresses(&self) -> Vec<SocketAddr> {
+        self.peers.values().map(|peer| peer.address).collect()
+    }
+
+    /// Delivers to one peer, dropping it if it cannot take the message.
+    pub fn send_to(&mut self, id: PeerId, message: Vec<u8>) -> bool {
+        let Some(peer) = self.peers.get(&id) else {
+            return false;
+        };
+
+        match peer.outbound.try_send(message) {
+            Ok(()) => true,
+            Err(_) => {
+                self.peers.remove(&id);
+                false
+            }
+        }
+    }
+
+    /// Delivers to every peer, dropping those that cannot take the message.
+    ///
+    /// `try_send` rather than `send`: a blocking send would let one stalled
+    /// socket hold the node's lock and stop delivery to everyone else, which is
+    /// the whole reason the writer thread exists.
+    pub fn broadcast(&mut self, message: &[u8]) -> usize {
+        let mut delivered = 0;
+        let mut failed = Vec::new();
+
+        for (id, peer) in &self.peers {
+            match peer.outbound.try_send(message.to_vec()) {
+                Ok(()) => delivered += 1,
+                Err(TrySendError::Full(_)) | Err(TrySendError::Disconnected(_)) => failed.push(*id),
+            }
+        }
+
+        for id in failed {
+            self.peers.remove(&id);
+        }
+
+        delivered
+    }
+}
 
 #[derive(Debug)]
 pub struct Node {
     pub config: Config,
+    pub peers: PeerTable,
 }
 
 impl Node {
     pub fn shared(config: Config) -> SharedNode {
-        Arc::new(Mutex::new(Self { config }))
+        Arc::new(Mutex::new(Self {
+            config,
+            peers: PeerTable::default(),
+        }))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::mpsc::{sync_channel, Receiver};
     use std::thread;
 
     fn config() -> Config {
@@ -24,6 +157,18 @@ mod tests {
             host_address: "127.0.0.1:34352".parse().unwrap(),
             addresses_to_connect: Vec::new(),
         }
+    }
+
+    fn address(port: u16) -> SocketAddr {
+        format!("127.0.0.1:{port}").parse().unwrap()
+    }
+
+    fn a_peer(table: &mut PeerTable, port: u16) -> (PeerId, Receiver<Vec<u8>>) {
+        let (outbound, queued) = sync_channel(OUTBOUND_QUEUE);
+        let id = table
+            .register(address(port), Origin::Accepted, outbound)
+            .expect("registering the first peers should succeed");
+        (id, queued)
     }
 
     #[test]
@@ -49,5 +194,171 @@ mod tests {
             );
             assert_eq!(node.lock().unwrap().config.host_address, address);
         }
+    }
+
+    #[test]
+    fn a_registered_peer_is_listed_until_it_is_removed() {
+        let mut table = PeerTable::default();
+        assert!(table.is_empty());
+
+        let (id, _queued) = a_peer(&mut table, 5000);
+        assert_eq!(1, table.len());
+        assert_eq!(vec![address(5000)], table.addresses());
+
+        assert!(table.remove(id).is_some());
+        assert!(
+            table.is_empty(),
+            "closing a connection must remove its peer"
+        );
+        assert!(table.remove(id).is_none(), "removing twice is not a peer");
+    }
+
+    #[test]
+    fn broadcast_reaches_every_peer() {
+        let mut table = PeerTable::default();
+        let queues: Vec<_> = (0..3)
+            .map(|index| a_peer(&mut table, 5000 + index).1)
+            .collect();
+
+        assert_eq!(3, table.broadcast(b"a block"));
+
+        for queued in &queues {
+            assert_eq!(b"a block".to_vec(), queued.try_recv().unwrap());
+            assert!(queued.try_recv().is_err(), "one broadcast, one message");
+        }
+    }
+
+    #[test]
+    fn send_to_reaches_exactly_one_peer() {
+        let mut table = PeerTable::default();
+        let (first, to_first) = a_peer(&mut table, 5000);
+        let (_, to_second) = a_peer(&mut table, 5001);
+
+        assert!(table.send_to(first, b"just for you".to_vec()));
+
+        assert_eq!(b"just for you".to_vec(), to_first.try_recv().unwrap());
+        assert!(
+            to_second.try_recv().is_err(),
+            "send_to must not reach anyone else"
+        );
+    }
+
+    #[test]
+    fn send_to_an_unknown_peer_delivers_nothing() {
+        let mut table = PeerTable::default();
+        let (_, to_first) = a_peer(&mut table, 5000);
+
+        assert!(!table.send_to(404, b"nobody".to_vec()));
+        assert!(to_first.try_recv().is_err());
+    }
+
+    #[test]
+    fn a_peer_that_never_drains_does_not_hold_up_the_others() {
+        let mut table = PeerTable::default();
+        let (stalled, never_drained) = a_peer(&mut table, 5000);
+        let (_, to_second) = a_peer(&mut table, 5001);
+        let (_, to_third) = a_peer(&mut table, 5002);
+
+        for _ in 0..OUTBOUND_QUEUE {
+            assert!(table.send_to(stalled, b"backlog".to_vec()));
+        }
+
+        assert_eq!(
+            2,
+            table.broadcast(b"a block"),
+            "the two healthy peers must still be reached"
+        );
+        assert_eq!(b"a block".to_vec(), to_second.try_recv().unwrap());
+        assert_eq!(b"a block".to_vec(), to_third.try_recv().unwrap());
+
+        assert_eq!(2, table.len(), "the stalled peer is dropped, not buffered");
+        drop(never_drained);
+    }
+
+    #[test]
+    fn a_peers_queue_does_not_grow_past_the_bound() {
+        let mut table = PeerTable::default();
+        let (stalled, never_drained) = a_peer(&mut table, 5000);
+
+        for queued_so_far in 0..OUTBOUND_QUEUE {
+            assert!(
+                table.send_to(stalled, b"backlog".to_vec()),
+                "the bound is {OUTBOUND_QUEUE}, so message {queued_so_far} should fit"
+            );
+        }
+
+        assert!(
+            !table.send_to(stalled, b"one too many".to_vec()),
+            "a queue past {OUTBOUND_QUEUE} is unbounded buffering, not backpressure"
+        );
+        assert!(table.is_empty(), "a peer that cannot keep up is dropped");
+
+        let drained = std::iter::from_fn(|| never_drained.try_recv().ok()).count();
+        assert_eq!(
+            OUTBOUND_QUEUE, drained,
+            "exactly the bound should have been buffered"
+        );
+    }
+
+    #[test]
+    fn a_peer_whose_writer_is_gone_is_dropped() {
+        let mut table = PeerTable::default();
+        let (id, queued) = a_peer(&mut table, 5000);
+        drop(queued);
+
+        assert!(!table.send_to(id, b"into the void".to_vec()));
+        assert!(table.is_empty(), "a peer with no writer is not a peer");
+    }
+
+    #[test]
+    fn dialling_the_same_address_twice_registers_one_peer() {
+        let mut table = PeerTable::default();
+        let (outbound, _first) = sync_channel(OUTBOUND_QUEUE);
+        table
+            .register(address(5000), Origin::Dialled, outbound)
+            .unwrap();
+
+        let (outbound, _second) = sync_channel(OUTBOUND_QUEUE);
+        assert_eq!(
+            Err(Refused::AlreadyDialled),
+            table.register(address(5000), Origin::Dialled, outbound)
+        );
+        assert_eq!(1, table.len());
+    }
+
+    #[test]
+    fn a_peer_that_dialled_us_is_not_confused_with_one_we_dialled() {
+        let mut table = PeerTable::default();
+        let (outbound, _dialled) = sync_channel(OUTBOUND_QUEUE);
+        table
+            .register(address(5000), Origin::Dialled, outbound)
+            .unwrap();
+
+        // An accepted connection shows an ephemeral source port, so it cannot be
+        // matched against a listen address until M2's version nonce exists.
+        let (outbound, _accepted) = sync_channel(OUTBOUND_QUEUE);
+        assert!(table
+            .register(address(5000), Origin::Accepted, outbound)
+            .is_ok());
+        assert_eq!(2, table.len());
+    }
+
+    #[test]
+    fn a_full_table_refuses_the_next_peer() {
+        let mut table = PeerTable::default();
+        let mut queues = Vec::new();
+
+        for index in 0..MAX_PEERS {
+            queues.push(a_peer(&mut table, 5000 + index as u16).1);
+        }
+        assert_eq!(MAX_PEERS, table.len());
+
+        let (outbound, _refused) = sync_channel(OUTBOUND_QUEUE);
+        assert_eq!(
+            Err(Refused::AtCapacity),
+            table.register(address(6000), Origin::Accepted, outbound),
+            "the policy is to refuse the newcomer, not to evict an established peer"
+        );
+        assert_eq!(MAX_PEERS, table.len());
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -2,11 +2,11 @@ use crate::messages::message::MessageReceived::{PingMessage, PongMessage};
 use crate::messages::message::{Message, MessageReceived};
 use crate::messages::ping::Ping;
 use crate::messages::pong::Pong;
-use crate::node::SharedNode;
+use crate::node::{Origin, PeerId, Refused, SharedNode, OUTBOUND_QUEUE};
 use anyhow::{anyhow, Result};
 use std::io::{ErrorKind, Read, Write};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -15,7 +15,7 @@ const PING_INTERVAL: Duration = Duration::from_secs(11);
 
 pub fn connect(addr: SocketAddr, node: SharedNode) -> Result<()> {
     let stream = TcpStream::connect(addr)?;
-    spawn_connection(stream, node);
+    spawn_connection(stream, node, Origin::Dialled);
 
     Ok(())
 }
@@ -23,7 +23,7 @@ pub fn connect(addr: SocketAddr, node: SharedNode) -> Result<()> {
 pub fn listen(listener: TcpListener, node: SharedNode) -> Result<()> {
     for stream in listener.incoming() {
         match stream {
-            Ok(stream) => spawn_connection(stream, Arc::clone(&node)),
+            Ok(stream) => spawn_connection(stream, Arc::clone(&node), Origin::Accepted),
             Err(e) => println!("Could not accept a connection: {e}"),
         }
     }
@@ -31,7 +31,9 @@ pub fn listen(listener: TcpListener, node: SharedNode) -> Result<()> {
     Ok(())
 }
 
-fn spawn_connection(stream: TcpStream, node: SharedNode) {
+/// Registration lives here, not in the two call sites that dial and accept, so
+/// they cannot drift apart about who is in the table.
+fn spawn_connection(stream: TcpStream, node: SharedNode, origin: Origin) {
     thread::spawn(move || {
         let peer = match stream.peer_addr() {
             Ok(peer) => peer,
@@ -41,10 +43,56 @@ fn spawn_connection(stream: TcpStream, node: SharedNode) {
             }
         };
 
-        if let Err(e) = handle_connection(stream, peer, node) {
+        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
+
+        // The reader keeps its own handle on the same bounded queue, so replying
+        // to a ping costs no lock while the bound still counts against the peer.
+        let registered = match Registered::open(&node, peer, origin, outbound.clone()) {
+            Ok(registered) => registered,
+            Err(refusal) => {
+                println!("Refusing a connection with {peer}: {refusal:?}");
+                return;
+            }
+        };
+
+        if let Err(e) = handle_connection(stream, peer, registered, outbound, queued) {
             println!("Connection with {peer} ended: {e:#}");
         }
     });
+}
+
+struct Registered {
+    node: SharedNode,
+    id: PeerId,
+}
+
+impl Registered {
+    fn open(
+        node: &SharedNode,
+        peer: SocketAddr,
+        origin: Origin,
+        outbound: SyncSender<Vec<u8>>,
+    ) -> Result<Registered, Refused> {
+        let id = node
+            .lock()
+            .expect("node lock poisoned")
+            .peers
+            .register(peer, origin, outbound)?;
+
+        Ok(Registered {
+            node: Arc::clone(node),
+            id,
+        })
+    }
+}
+
+impl Drop for Registered {
+    fn drop(&mut self) {
+        // Recovering the guard rather than unwrapping: this runs while a panic
+        // may already be unwinding, and panicking again would abort.
+        let mut node = self.node.lock().unwrap_or_else(|held| held.into_inner());
+        node.peers.remove(self.id);
+    }
 }
 
 struct ShutdownOnDrop(TcpStream);
@@ -56,16 +104,28 @@ impl Drop for ShutdownOnDrop {
     }
 }
 
-fn handle_connection(stream: TcpStream, peer_addr: SocketAddr, node: SharedNode) -> Result<()> {
+fn handle_connection(
+    stream: TcpStream,
+    peer_addr: SocketAddr,
+    registered: Registered,
+    outbound: SyncSender<Vec<u8>>,
+    queued: Receiver<Vec<u8>>,
+) -> Result<()> {
     let write_half = ShutdownOnDrop(stream.try_clone()?);
-    let (outbound, queued) = mpsc::channel();
 
-    let host_address = node.lock().expect("node lock poisoned").config.host_address;
-    println!("{host_address} is handling a connection from {peer_addr}");
+    let (host_address, peers) = {
+        let node = registered.node.lock().expect("node lock poisoned");
+        (node.config.host_address, node.peers.len())
+    };
+    println!("{host_address} is handling a connection from {peer_addr} ({peers} peers)");
 
     let writer = thread::spawn(move || write_loop(&write_half.0, queued, PING_INTERVAL));
 
     let read_result = read_loop(stream, peer_addr, outbound);
+
+    // Before the join, not after: the table holds a Sender for this peer, and
+    // while it does the writer never sees the disconnect that ends it.
+    drop(registered);
 
     match writer.join() {
         Ok(write_result) => read_result.and(write_result),
@@ -97,7 +157,7 @@ fn write_loop<W: Write>(
 fn read_loop<R: Read>(
     mut reader: R,
     peer_addr: SocketAddr,
-    outbound: Sender<Vec<u8>>,
+    outbound: SyncSender<Vec<u8>>,
 ) -> Result<()> {
     let mut buffer = [0u8; 4096];
     let mut recv_buffer: Vec<u8> = Vec::new();
@@ -116,7 +176,7 @@ fn read_loop<R: Read>(
 }
 
 fn process_incoming_bytes(
-    outbound: &Sender<Vec<u8>>,
+    outbound: &SyncSender<Vec<u8>>,
     recv_buffer: &mut Vec<u8>,
     buffer: &[u8],
 ) -> Result<()> {
@@ -129,12 +189,19 @@ fn process_incoming_bytes(
     Ok(())
 }
 
-fn handle_messages(outbound: &Sender<Vec<u8>>, message: MessageReceived) -> Result<()> {
+fn handle_messages(outbound: &SyncSender<Vec<u8>>, message: MessageReceived) -> Result<()> {
     match message {
         PingMessage(ping) => {
             println!("Ping received {:?}", ping);
             let pong = Pong::new(ping.payload)?;
-            outbound.send(Message::new(pong)?.get_raw_format()?)?;
+            outbound
+                .try_send(Message::new(pong)?.get_raw_format()?)
+                .map_err(|full| match full {
+                    TrySendError::Full(_) => {
+                        anyhow!("peer sends faster than its socket accepts replies")
+                    }
+                    TrySendError::Disconnected(_) => anyhow!("the writer for this peer is gone"),
+                })?;
         }
         PongMessage(pong) => {
             println!("Pong received {:?}", pong)
@@ -176,7 +243,7 @@ mod tests {
 
     #[test]
     fn the_first_ping_is_written_without_waiting_for_the_interval() {
-        let (outbound, queued) = mpsc::channel();
+        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
         drop(outbound);
 
         let mut output = Vec::new();
@@ -190,7 +257,7 @@ mod tests {
 
     #[test]
     fn a_message_enqueued_from_another_thread_is_written_to_the_peer() {
-        let (outbound, queued) = mpsc::channel();
+        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
         let ping = Ping::new();
         let nonce = ping.nonce;
         let pong = framed(Pong::new(ping).unwrap());
@@ -217,7 +284,7 @@ mod tests {
         let interval = Duration::from_millis(20);
         let run_for = Duration::from_millis(300);
 
-        let (outbound, queued) = mpsc::channel::<Vec<u8>>();
+        let (outbound, queued) = mpsc::sync_channel::<Vec<u8>>(OUTBOUND_QUEUE);
         let holder = thread::spawn(move || {
             thread::sleep(run_for);
             drop(outbound);
@@ -243,7 +310,7 @@ mod tests {
 
     #[test]
     fn an_inbound_ping_is_answered_with_a_pong_on_the_outbound_channel() {
-        let (outbound, queued) = mpsc::channel();
+        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
         let mut recv_buffer = Vec::new();
         let (ping, nonce) = framed_ping();
 
@@ -261,7 +328,7 @@ mod tests {
 
     #[test]
     fn an_oversized_header_fails_the_connection_rather_than_being_awaited() {
-        let (outbound, queued) = mpsc::channel();
+        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
         let mut recv_buffer = Vec::new();
         let header = crate::messages::message::header_claiming(u32::MAX);
 
@@ -295,7 +362,7 @@ mod tests {
             }
         }
 
-        let (outbound, queued) = mpsc::channel();
+        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
         let (ping, nonce) = framed_ping();
         let reader = InterruptsOnce {
             ping,
@@ -341,6 +408,28 @@ mod tests {
         (peer, accepted, peer_addr)
     }
 
+    fn eventually(mut settled: impl FnMut() -> bool, what: &str) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+
+        while Instant::now() < deadline {
+            if settled() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        panic!("{what} within 5s");
+    }
+
+    /// What spawn_connection does, minus the registry, for tests about the
+    /// thread pair rather than about the peer table.
+    fn handle_alone(stream: TcpStream, peer_addr: SocketAddr, node: SharedNode) -> Result<()> {
+        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
+        let registered = Registered::open(&node, peer_addr, Origin::Accepted, outbound.clone())
+            .expect("an empty table should accept a peer");
+        handle_connection(stream, peer_addr, registered, outbound, queued)
+    }
+
     fn a_node() -> SharedNode {
         Node::shared(Config {
             host_address: "127.0.0.1:34352".parse().unwrap(),
@@ -352,7 +441,7 @@ mod tests {
     fn a_connection_pings_its_peer_and_answers_the_peers_ping() {
         let (mut peer, accepted, peer_addr) = a_connected_pair();
 
-        thread::spawn(move || handle_connection(accepted, peer_addr, a_node()));
+        thread::spawn(move || handle_alone(accepted, peer_addr, a_node()));
 
         let mut buffer = Vec::new();
         assert!(
@@ -370,12 +459,64 @@ mod tests {
     }
 
     #[test]
+    fn a_connection_registers_a_peer_and_closing_it_removes_them() {
+        let (peer, accepted, _) = a_connected_pair();
+        let node = a_node();
+        let watched = Arc::clone(&node);
+
+        spawn_connection(accepted, node, Origin::Accepted);
+        eventually(
+            || watched.lock().unwrap().peers.len() == 1,
+            "the connection never registered a peer",
+        );
+
+        drop(peer);
+        eventually(
+            || watched.lock().unwrap().peers.is_empty(),
+            "the peer was still registered after its connection closed",
+        );
+    }
+
+    #[test]
+    fn a_refused_connection_leaves_the_table_as_it_found_it() {
+        let node = a_node();
+        let mut held = Vec::new();
+
+        for index in 0..crate::node::MAX_PEERS {
+            let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
+            held.push(queued);
+            let filler = format!("127.0.0.1:{}", 5000 + index).parse().unwrap();
+            node.lock()
+                .unwrap()
+                .peers
+                .register(filler, Origin::Accepted, outbound)
+                .expect("the table should accept peers up to its bound");
+        }
+
+        let (mut peer, accepted, _) = a_connected_pair();
+        spawn_connection(accepted, Arc::clone(&node), Origin::Accepted);
+
+        let mut discarded = [0u8; 64];
+        assert_eq!(
+            0,
+            peer.read(&mut discarded)
+                .expect("the refusal should close, not hang"),
+            "a refused peer should be hung up on, not left connected in silence"
+        );
+        assert_eq!(
+            crate::node::MAX_PEERS,
+            node.lock().unwrap().peers.len(),
+            "a refused connection must not displace an established peer"
+        );
+    }
+
+    #[test]
     fn both_threads_end_when_the_peer_disconnects() {
         let (peer, accepted, peer_addr) = a_connected_pair();
         let (done, finished) = mpsc::channel();
 
         thread::spawn(move || {
-            let _ = handle_connection(accepted, peer_addr, a_node());
+            let _ = handle_alone(accepted, peer_addr, a_node());
             done.send(()).unwrap();
         });
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -6,7 +6,7 @@ use crate::node::{Origin, PeerId, Refused, SharedNode, OUTBOUND_QUEUE};
 use anyhow::{anyhow, Result};
 use std::io::{ErrorKind, Read, Write};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -45,9 +45,7 @@ fn spawn_connection(stream: TcpStream, node: SharedNode, origin: Origin) {
 
         let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
 
-        // The reader keeps its own handle on the same bounded queue, so replying
-        // to a ping costs no lock while the bound still counts against the peer.
-        let registered = match Registered::open(&node, peer, origin, outbound.clone()) {
+        let registered = match Registered::open(&node, peer, origin, outbound) {
             Ok(registered) => registered,
             Err(refusal) => {
                 println!("Refusing a connection with {peer}: {refusal:?}");
@@ -55,7 +53,7 @@ fn spawn_connection(stream: TcpStream, node: SharedNode, origin: Origin) {
             }
         };
 
-        if let Err(e) = handle_connection(stream, peer, registered, outbound, queued) {
+        if let Err(e) = handle_connection(stream, peer, registered, queued) {
             println!("Connection with {peer} ended: {e:#}");
         }
     });
@@ -84,6 +82,25 @@ impl Registered {
             id,
         })
     }
+
+    /// The table owns this peer's only sender, so every outbound byte goes
+    /// through it. That is what lets dropping a peer end its connection: the
+    /// last sender goes with the entry, the writer sees the disconnect, and its
+    /// shutdown wakes the reader.
+    fn deliver(&self, message: Vec<u8>) -> Result<()> {
+        let reached = self
+            .node
+            .lock()
+            .expect("node lock poisoned")
+            .peers
+            .send_to(self.id, message);
+
+        if reached {
+            Ok(())
+        } else {
+            Err(anyhow!("peer cannot keep up with its own replies"))
+        }
+    }
 }
 
 impl Drop for Registered {
@@ -108,7 +125,6 @@ fn handle_connection(
     stream: TcpStream,
     peer_addr: SocketAddr,
     registered: Registered,
-    outbound: SyncSender<Vec<u8>>,
     queued: Receiver<Vec<u8>>,
 ) -> Result<()> {
     let write_half = ShutdownOnDrop(stream.try_clone()?);
@@ -121,9 +137,9 @@ fn handle_connection(
 
     let writer = thread::spawn(move || write_loop(&write_half.0, queued, PING_INTERVAL));
 
-    let read_result = read_loop(stream, peer_addr, outbound);
+    let read_result = read_loop(stream, peer_addr, &registered);
 
-    // Before the join, not after: the table holds a Sender for this peer, and
+    // Before the join, not after: the table holds this peer's only sender, and
     // while it does the writer never sees the disconnect that ends it.
     drop(registered);
 
@@ -154,11 +170,7 @@ fn write_loop<W: Write>(
     }
 }
 
-fn read_loop<R: Read>(
-    mut reader: R,
-    peer_addr: SocketAddr,
-    outbound: SyncSender<Vec<u8>>,
-) -> Result<()> {
+fn read_loop<R: Read>(mut reader: R, peer_addr: SocketAddr, registered: &Registered) -> Result<()> {
     let mut buffer = [0u8; 4096];
     let mut recv_buffer: Vec<u8> = Vec::new();
 
@@ -168,7 +180,7 @@ fn read_loop<R: Read>(
                 println!("Connection with {peer_addr} closed");
                 return Ok(());
             }
-            Ok(n) => process_incoming_bytes(&outbound, &mut recv_buffer, &buffer[..n])?,
+            Ok(n) => process_incoming_bytes(registered, &mut recv_buffer, &buffer[..n])?,
             Err(e) if e.kind() == ErrorKind::Interrupted => {}
             Err(e) => return Err(e.into()),
         }
@@ -176,7 +188,7 @@ fn read_loop<R: Read>(
 }
 
 fn process_incoming_bytes(
-    outbound: &SyncSender<Vec<u8>>,
+    registered: &Registered,
     recv_buffer: &mut Vec<u8>,
     buffer: &[u8],
 ) -> Result<()> {
@@ -184,24 +196,17 @@ fn process_incoming_bytes(
     while let (Some(message), bytes_consumed) = MessageReceived::try_parse_message(recv_buffer)? {
         recv_buffer.drain(0..bytes_consumed);
 
-        handle_messages(outbound, message)?
+        handle_messages(registered, message)?
     }
     Ok(())
 }
 
-fn handle_messages(outbound: &SyncSender<Vec<u8>>, message: MessageReceived) -> Result<()> {
+fn handle_messages(registered: &Registered, message: MessageReceived) -> Result<()> {
     match message {
         PingMessage(ping) => {
             println!("Ping received {:?}", ping);
             let pong = Pong::new(ping.payload)?;
-            outbound
-                .try_send(Message::new(pong)?.get_raw_format()?)
-                .map_err(|full| match full {
-                    TrySendError::Full(_) => {
-                        anyhow!("peer sends faster than its socket accepts replies")
-                    }
-                    TrySendError::Disconnected(_) => anyhow!("the writer for this peer is gone"),
-                })?;
+            registered.deliver(Message::new(pong)?.get_raw_format()?)?;
         }
         PongMessage(pong) => {
             println!("Pong received {:?}", pong)
@@ -310,11 +315,11 @@ mod tests {
 
     #[test]
     fn an_inbound_ping_is_answered_with_a_pong_on_the_outbound_channel() {
-        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
+        let (registered, queued) = a_registered_peer();
         let mut recv_buffer = Vec::new();
         let (ping, nonce) = framed_ping();
 
-        process_incoming_bytes(&outbound, &mut recv_buffer, &ping).unwrap();
+        process_incoming_bytes(&registered, &mut recv_buffer, &ping).unwrap();
 
         assert!(recv_buffer.is_empty(), "the ping should be fully consumed");
 
@@ -328,11 +333,11 @@ mod tests {
 
     #[test]
     fn an_oversized_header_fails_the_connection_rather_than_being_awaited() {
-        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
+        let (registered, queued) = a_registered_peer();
         let mut recv_buffer = Vec::new();
         let header = crate::messages::message::header_claiming(u32::MAX);
 
-        let error = process_incoming_bytes(&outbound, &mut recv_buffer, &header)
+        let error = process_incoming_bytes(&registered, &mut recv_buffer, &header)
             .expect_err("a header claiming 4 GB must fail the connection, not be waited on");
 
         assert!(format!("{error:#}").contains("too large"), "got: {error:#}");
@@ -362,14 +367,14 @@ mod tests {
             }
         }
 
-        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
+        let (registered, queued) = a_registered_peer();
         let (ping, nonce) = framed_ping();
         let reader = InterruptsOnce {
             ping,
             interrupted: false,
         };
 
-        read_loop(reader, "127.0.0.1:1".parse().unwrap(), outbound)
+        read_loop(reader, "127.0.0.1:1".parse().unwrap(), &registered)
             .expect("a signal-interrupted read must be retried, not fail the connection");
 
         let reply = queued.try_recv().expect("the ping after the interrupt");
@@ -425,9 +430,24 @@ mod tests {
     /// thread pair rather than about the peer table.
     fn handle_alone(stream: TcpStream, peer_addr: SocketAddr, node: SharedNode) -> Result<()> {
         let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
-        let registered = Registered::open(&node, peer_addr, Origin::Accepted, outbound.clone())
+        let registered = Registered::open(&node, peer_addr, Origin::Accepted, outbound)
             .expect("an empty table should accept a peer");
-        handle_connection(stream, peer_addr, registered, outbound, queued)
+        handle_connection(stream, peer_addr, registered, queued)
+    }
+
+    /// A peer in a node's table, plus the queue its writer would drain.
+    fn a_registered_peer() -> (Registered, Receiver<Vec<u8>>) {
+        let node = a_node();
+        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
+        let registered = Registered::open(
+            &node,
+            "127.0.0.1:5000".parse().unwrap(),
+            Origin::Accepted,
+            outbound,
+        )
+        .expect("an empty table should accept a peer");
+
+        (registered, queued)
     }
 
     fn a_node() -> SharedNode {
@@ -475,6 +495,34 @@ mod tests {
             || watched.lock().unwrap().peers.is_empty(),
             "the peer was still registered after its connection closed",
         );
+    }
+
+    #[test]
+    fn dropping_a_peer_from_the_table_ends_its_connection() {
+        let (mut peer, accepted, _) = a_connected_pair();
+        let node = a_node();
+        let watched = Arc::clone(&node);
+
+        spawn_connection(accepted, node, Origin::Accepted);
+        eventually(
+            || watched.lock().unwrap().peers.len() == 1,
+            "the connection never registered a peer",
+        );
+
+        // What broadcast does to a peer that cannot keep up. Removing the entry
+        // must take the connection with it, or the threads and the peer's
+        // recv_buffer outlive the table that is supposed to bound them.
+        let id = watched.lock().unwrap().peers.ids()[0];
+        watched.lock().unwrap().peers.remove(id);
+
+        let mut discarded = [0u8; 64];
+        loop {
+            match peer.read(&mut discarded) {
+                Ok(0) => return,
+                Ok(_) => continue,
+                Err(e) => panic!("dropping a peer must close its socket, got {e}"),
+            }
+        }
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -13,6 +13,11 @@ use std::time::{Duration, Instant};
 
 const PING_INTERVAL: Duration = Duration::from_secs(11);
 
+/// A peer that has not accepted a byte in this long is not slow, it is gone.
+/// Without it `write_all` blocks forever on a socket whose peer stopped
+/// reading, and no amount of dropping the peer elsewhere can end that.
+const WRITE_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub fn connect(addr: SocketAddr, node: SharedNode) -> Result<()> {
     let stream = TcpStream::connect(addr)?;
     spawn_connection(stream, node, Origin::Dialled);
@@ -31,8 +36,7 @@ pub fn listen(listener: TcpListener, node: SharedNode) -> Result<()> {
     Ok(())
 }
 
-/// Registration lives here, not in the two call sites that dial and accept, so
-/// they cannot drift apart about who is in the table.
+// Registration lives here, not in the two call sites that dial and accept.
 fn spawn_connection(stream: TcpStream, node: SharedNode, origin: Origin) {
     thread::spawn(move || {
         let peer = match stream.peer_addr() {
@@ -83,10 +87,6 @@ impl Registered {
         })
     }
 
-    /// The table owns this peer's only sender, so every outbound byte goes
-    /// through it. That is what lets dropping a peer end its connection: the
-    /// last sender goes with the entry, the writer sees the disconnect, and its
-    /// shutdown wakes the reader.
     fn deliver(&self, message: Vec<u8>) -> Result<()> {
         let reached = self
             .node
@@ -128,6 +128,7 @@ fn handle_connection(
     queued: Receiver<Vec<u8>>,
 ) -> Result<()> {
     let write_half = ShutdownOnDrop(stream.try_clone()?);
+    write_half.0.set_write_timeout(Some(WRITE_TIMEOUT))?;
 
     let (host_address, peers) = {
         let node = registered.node.lock().expect("node lock poisoned");
@@ -282,6 +283,30 @@ mod tests {
             [PingMessage(_), PongMessage(pong)] => assert_eq!(nonce, pong.payload.nonce),
             other => panic!("expected the opening ping then the enqueued pong, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn a_stalled_write_ends_the_connection_rather_than_blocking_forever() {
+        struct NeverAccepts;
+
+        impl Write for NeverAccepts {
+            fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::from(ErrorKind::WouldBlock))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
+        outbound.try_send(b"backlog".to_vec()).unwrap();
+
+        // What a socket does once its write timeout expires. Dropping the peer
+        // cannot end this connection on its own: mpsc hands the writer every
+        // buffered message before it ever reports Disconnected, so the writer
+        // must give up on the socket itself.
+        write_loop(NeverAccepts, queued, NEVER)
+            .expect_err("a write that cannot proceed must end the connection");
     }
 
     #[test]
@@ -509,9 +534,10 @@ mod tests {
             "the connection never registered a peer",
         );
 
-        // What broadcast does to a peer that cannot keep up. Removing the entry
-        // must take the connection with it, or the threads and the peer's
-        // recv_buffer outlive the table that is supposed to bound them.
+        // Removing the entry must take the connection with it, or the threads
+        // and the peer's recv_buffer outlive the table meant to bound them.
+        // This covers eviction with a drained queue; a full one is
+        // a_stalled_write_ends_the_connection_rather_than_blocking_forever.
         let id = watched.lock().unwrap().peers.ids()[0];
         watched.lock().unwrap().peers.remove(id);
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -287,10 +287,20 @@ mod tests {
 
     #[test]
     fn a_stalled_write_ends_the_connection_rather_than_blocking_forever() {
-        struct NeverAccepts;
+        /// Takes the opening ping, then behaves like a socket whose write
+        /// timeout has expired — so the failure under test is the *queued*
+        /// message, not the ping.
+        #[derive(Default)]
+        struct AcceptsThenStalls {
+            taken: usize,
+        }
 
-        impl Write for NeverAccepts {
-            fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+        impl Write for AcceptsThenStalls {
+            fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+                if self.taken == 0 {
+                    self.taken += 1;
+                    return Ok(buffer.len());
+                }
                 Err(std::io::Error::from(ErrorKind::WouldBlock))
             }
             fn flush(&mut self) -> std::io::Result<()> {
@@ -300,13 +310,27 @@ mod tests {
 
         let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
         outbound.try_send(b"backlog".to_vec()).unwrap();
+        drop(outbound);
 
-        // What a socket does once its write timeout expires. Dropping the peer
-        // cannot end this connection on its own: mpsc hands the writer every
-        // buffered message before it ever reports Disconnected, so the writer
-        // must give up on the socket itself.
-        write_loop(NeverAccepts, queued, NEVER)
+        // Dropping the peer cannot end this connection on its own: mpsc hands
+        // the writer every buffered message before it ever reports
+        // Disconnected, so the writer must give up on the socket itself.
+        write_loop(AcceptsThenStalls::default(), queued, NEVER)
             .expect_err("a write that cannot proceed must end the connection");
+    }
+
+    #[test]
+    fn a_connection_bounds_how_long_a_write_may_block() {
+        let (_peer, accepted, peer_addr) = a_connected_pair();
+        let observer = accepted.try_clone().unwrap();
+
+        thread::spawn(move || handle_alone(accepted, peer_addr, a_node()));
+
+        eventually(
+            || observer.write_timeout().unwrap().is_some(),
+            "the write half never had its blocking bounded",
+        );
+        assert_eq!(Some(WRITE_TIMEOUT), observer.write_timeout().unwrap());
     }
 
     #[test]

--- a/test/functional/framework/node.py
+++ b/test/functional/framework/node.py
@@ -1,7 +1,7 @@
 """Launching the real binary, and reading what it says.
 
 Set AVICOIN_BIN to test a binary built elsewhere; otherwise the debug build is
-used, and built if missing.
+rebuilt and used.
 """
 
 import os
@@ -10,6 +10,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from functools import cache
 from pathlib import Path
 from typing import List, Optional
 
@@ -19,6 +20,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_BINARY = REPO_ROOT / "target" / "debug" / "avicoin"
 
 
+@cache
 def binary_path() -> Path:
     override = os.environ.get("AVICOIN_BIN")
     if override:
@@ -27,13 +29,16 @@ def binary_path() -> Path:
             raise FileNotFoundError(f"AVICOIN_BIN={override} does not exist")
         return path
 
-    if not DEFAULT_BINARY.exists():
-        if shutil.which("cargo") is None:
-            raise RuntimeError(
-                "cargo is not on PATH and the binary is not built; "
-                "build it first or set AVICOIN_BIN"
-            )
-        subprocess.run(["cargo", "build", "--quiet"], cwd=REPO_ROOT, check=True)
+    if shutil.which("cargo") is None:
+        raise RuntimeError(
+            "cargo is not on PATH; build the node first and set AVICOIN_BIN"
+        )
+
+    # Always build, never "build if missing". An existing binary may predate the
+    # change under test -- `cargo clippy` alone leaves a stale one behind -- and a
+    # suite that silently tests the wrong binary is the failure this whole
+    # arrangement exists to prevent. Cargo is a no-op when it is already current.
+    subprocess.run(["cargo", "build", "--quiet"], cwd=REPO_ROOT, check=True)
 
     if not DEFAULT_BINARY.exists():
         raise RuntimeError(f"no binary at {DEFAULT_BINARY} after cargo build")

--- a/test/functional/framework/node.py
+++ b/test/functional/framework/node.py
@@ -1,7 +1,7 @@
 """Launching the real binary, and reading what it says.
 
 Set AVICOIN_BIN to test a binary built elsewhere; otherwise the debug build is
-rebuilt and used.
+used, and built if missing.
 """
 
 import os
@@ -10,7 +10,6 @@ import subprocess
 import tempfile
 import threading
 import time
-from functools import cache
 from pathlib import Path
 from typing import List, Optional
 
@@ -20,7 +19,6 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_BINARY = REPO_ROOT / "target" / "debug" / "avicoin"
 
 
-@cache
 def binary_path() -> Path:
     override = os.environ.get("AVICOIN_BIN")
     if override:
@@ -29,16 +27,13 @@ def binary_path() -> Path:
             raise FileNotFoundError(f"AVICOIN_BIN={override} does not exist")
         return path
 
-    if shutil.which("cargo") is None:
-        raise RuntimeError(
-            "cargo is not on PATH; build the node first and set AVICOIN_BIN"
-        )
-
-    # Always build, never "build if missing". An existing binary may predate the
-    # change under test -- `cargo clippy` alone leaves a stale one behind -- and a
-    # suite that silently tests the wrong binary is the failure this whole
-    # arrangement exists to prevent. Cargo is a no-op when it is already current.
-    subprocess.run(["cargo", "build", "--quiet"], cwd=REPO_ROOT, check=True)
+    if not DEFAULT_BINARY.exists():
+        if shutil.which("cargo") is None:
+            raise RuntimeError(
+                "cargo is not on PATH and the binary is not built; "
+                "build it first or set AVICOIN_BIN"
+            )
+        subprocess.run(["cargo", "build", "--quiet"], cwd=REPO_ROOT, check=True)
 
     if not DEFAULT_BINARY.exists():
         raise RuntimeError(f"no binary at {DEFAULT_BINARY} after cargo build")


### PR DESCRIPTION
Closes #16.

`PeerTable` maps a `PeerId` to that peer's address, origin and outbound sender. `spawn_connection` registers — one place, so dialling and accepting cannot drift — and a guard removes on any exit including a panic.

## The bug the review found, and why it mattered

The first pass had eviction as **bookkeeping only**. On a full queue the `PeerHandle` was removed, but the reader held a *cloned* sender, so the writer never saw a disconnect: both threads, the socket, and the peer's up-to-32 MiB `recv_buffer` carried on outside the table. A stalled peer freed a `MAX_PEERS` slot while still holding its buffer — so the cap could be exceeded by exactly the peers that stall, inverting the reason the cap exists.

Fix: **the table holds each peer's only sender**, and the reader enqueues through it. Removing the entry drops the last sender → writer sees `Disconnected` → its shutdown wakes the reader → connection ends.

That was still not enough, and the second review round caught why:

```
$ # after dropping the last sender, with 3 buffered messages:
after dropping the last sender, the receiver still yielded: [1, 2, 3]
$ grep -rn set_write_timeout src/
  none — write_all can block indefinitely
```

`mpsc` **drains buffered messages before reporting `Disconnected`**. So evicting a peer whose queue was full made the writer go on calling `write_all` against the very socket that stalled — forever, with no write timeout. `ShutdownOnDrop` never ran, the reader stayed parked: the original defect, for precisely the path eviction exists for.

The real fix is a **30s write timeout** on the write half. A peer that has stopped reading now ends its own connection whether or not anything evicted it — this was a leak independent of the table.

## Acceptance criteria

| | |
|---|---|
| register on connect, remove on close | `a_connection_registers_a_peer_and_closing_it_removes_them` (real sockets, polls both ways) |
| `broadcast` reaches every peer | `broadcast_reaches_every_peer` |
| `send_to` reaches exactly one | `send_to_reaches_exactly_one_peer`, asserts the other receiver is empty |
| in-memory channels, no sockets | every `PeerTable` test |
| a stalled peer doesn't block others | `a_peer_that_never_drains_does_not_hold_up_the_others` — fills to the bound first, then asserts `broadcast == 2` |
| no duplicate entry for a dialled peer | `dialling_the_same_address_twice_registers_one_peer`. The issue's softened reading; `a_peer_that_dialled_us_is_not_confused_with_one_we_dialled` asserts `2` and documents the gap rather than hiding it — real identity needs M2's version nonce |
| a peer bound exists | `MAX_PEERS = 32`, `a_full_table_refuses_the_next_peer` |
| bounded channel, laggards dropped | `a_peers_queue_does_not_grow_past_the_bound` drains and counts exactly `OUTBOUND_QUEUE` |

**Policy, stated where a reader looks** (the issue explicitly asks): at the cap we **refuse the newcomer** rather than evict an established peer — there is no peer scoring to evict on. In `ARCHITECTURE.md`, not just a commit message.

## Mutations

Ten, each verified to actually apply, each caught: removal-on-drop, peer cap, dedup, broadcast-not-dropping-failures, broadcast-stopping-early, send_to-reaching-everyone, drop-ordering-before-join, reader-keeping-a-clone, **no-write-timeout**, **writer-ignoring-a-failed-write**.

The last two **survived the first run** — my stalled-write test failed on the opening ping so it never reached the queued branch, and nothing pinned that the socket was configured at all. Both now have tests that fail without the fix.

The bound itself can't be mutated: `register` takes a `SyncSender`, so an unbounded `mpsc::channel()` is a compile error rather than a silent regression.

## Stated honestly rather than glossed

- Teardown is bounded by the 30s timeout, not immediate, so a peer can briefly outlive its table entry.
- `OUTBOUND_QUEUE` bounds **messages, not bytes** — a memory bound today because every queued message is a 32-byte pong, and not one once blocks are relayed.
- Inbound and outbound share `MAX_PEERS`, so an inbound flood can crowd out configured dials. Fine with a static peer list; not once discovery lands in M2.

`node.rs` docs were describing the design before this ticket — ARCHITECTURE listed it "Not built" and `PeerHandle` as carrying `state`, the glossary said `PeerTable` was "Not yet built", CLAUDE.md described an unbounded channel. All corrected; `PeerId`, `Origin`, `MAX_PEERS`, `OUTBOUND_QUEUE` gained glossary entries.

Green: 125 unit, 22 functional. Clippy unchanged but for two new dead-code entries — `send_to`/`broadcast` have no caller until relay lands in M3, which is the signal working, so no `#[allow]`.

The harness rebuild fix is split out as #35, per the review.