### PR TITLE
Build a merkle tree, not a chain

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,7 +103,7 @@ These hold everywhere and are not up for per-module negotiation:
 | `config.rs` | Resolves configuration and validates addresses into `SocketAddr`; `resolve` is the canonical statement of precedence | Built |
 | `messages/` | `Header`, `Message<T>`, `Payload` trait, `MessageReceived` dispatch | Built (ping/pong) |
 | `protocol.rs` | Per-connection reader and writer threads; the writer drives the ping timer | Built |
-| `block.rs` | Header assembly, merkle root over wtxids, target math, `mine()` | Built — merkle leaf and pair order change per ADR-0003/0010; not wired to the node |
+| `block.rs` | Header assembly, merkle construction, target math, `mine()` | Built — tree is correct (ADR-0010); leaves become wtxids with ADR-0003 in M3; not wired to the node |
 | `transaction.rs` | `Transaction` / `TxIn` / `TxOut` / `Outpoint` / `Witness`, dual serialization | Built — reshaped by ADR-0003/0008/0011 |
 | `wallet.rs` | Keypair, `TxBuilder`, signing | Stubbed — UTXO selection, balance, change are TODO |
 | `block_storage.rs` | `blocks.dat` / `undo.dat` framing and offset reads | Empty stub (ADR-0013) |

--- a/docs/adr/0010-merkle-construction.md
+++ b/docs/adr/0010-merkle-construction.md
@@ -99,6 +99,31 @@ one-line leaf change plus a pair-order fix described in the Consequences section
 It is a replacement of the whole construction. The acceptance criteria live in the
 tracking issue.
 
+### Landed 2026-07-31 — the construction, not yet the leaves
+
+`block::merkle_root` replaces the loop: each level is built into a **new** vector,
+paired left to right, duplicating the last node wherever a level has an odd count.
+Feeding a level's results back into the vector being read was the whole defect.
+
+It is pinned by a known-answer test — Bitcoin block 170's two transactions against
+that block's published merkle root — plus the genesis single-leaf case and direct
+structural assertions for four and six leaves. Six is what separates per-level
+duplication from padding the leaf list to a power of two; the two agree at three
+and five, so a smaller odd case would not have distinguished them. Restoring the
+original algorithm turns four of these red.
+
+Two parts of this decision remain, each blocked on work that does not exist yet:
+
+- **Leaves are still txids.** They become wtxids when witness separation lands in
+  M3 ([ADR-0003](0003-transaction-witness-format.md)). The tree algorithm is
+  indifferent to which hash it is given, so this is a leaf change now, exactly as
+  the Consequences section originally described.
+- **The duplicate-wtxid rejection is not implemented**, nor the rule that such a
+  rejection must not cache the block hash as permanently invalid. Both are block
+  *validation*, which arrives with M4 — there is no validation path to add them
+  to. The CVE-2012-2459 exposure they close is therefore still open, and stays
+  tracked in the milestone rather than being quietly considered done here.
+
 - `get_merkle_root_hash` is **rewritten**, not adjusted — see the Correction
   above. It gains a known-answer test against a real block, which is the thing it
   has never had.

--- a/docs/adr/0010-merkle-construction.md
+++ b/docs/adr/0010-merkle-construction.md
@@ -99,7 +99,22 @@ one-line leaf change plus a pair-order fix described in the Consequences section
 It is a replacement of the whole construction. The acceptance criteria live in the
 tracking issue.
 
-### Landed 2026-07-31 — the construction, not yet the leaves
+## Consequences
+
+- `get_merkle_root_hash` is **rewritten**, not adjusted — see the Correction
+  above. It gains a known-answer test against a real block, which is the thing it
+  has never had.
+- Block validation gains one rule (duplicate wtxids) and one requirement on the
+  *failure path* (do not poison the hash) — the latter being easy to implement and
+  easy to forget, so it belongs in a test rather than only in prose.
+- The tree remains non-injective. Correctness rests on the duplicate check
+  running, which is a weaker guarantee than Option A's structural one, accepted in
+  exchange for computing block hashes the way every Bitcoin reference does.
+- Settles the glossary term **merkle root**.
+
+## What has landed
+
+*2026-07-31 — the construction, not yet the leaves.*
 
 `block::merkle_root` replaces the loop: each level is built into a **new** vector,
 paired left to right, duplicating the last node wherever a level has an odd count.
@@ -107,10 +122,14 @@ Feeding a level's results back into the vector being read was the whole defect.
 
 It is pinned by a known-answer test — Bitcoin block 170's two transactions against
 that block's published merkle root — plus the genesis single-leaf case and direct
-structural assertions for four and six leaves. Six is what separates per-level
-duplication from padding the leaf list to a power of two; the two agree at three
-and five, so a smaller odd case would not have distinguished them. Restoring the
-original algorithm turns four of these red.
+structural assertions for four and six leaves. Restoring the original algorithm
+turns four of these red.
+
+**Six leaves, specifically.** Per-level duplication and padding the leaf list out
+to a power of two agree at every count up to nine except six; three and five do
+*not* distinguish them. So the three-leaf test pins that an unpaired node is
+duplicated rather than dropped or zero-padded, but only the six-leaf one pins
+*where* that duplication happens.
 
 Two parts of this decision remain, each blocked on work that does not exist yet:
 
@@ -123,14 +142,3 @@ Two parts of this decision remain, each blocked on work that does not exist yet:
   *validation*, which arrives with M4 — there is no validation path to add them
   to. The CVE-2012-2459 exposure they close is therefore still open, and stays
   tracked in the milestone rather than being quietly considered done here.
-
-- `get_merkle_root_hash` is **rewritten**, not adjusted — see the Correction
-  above. It gains a known-answer test against a real block, which is the thing it
-  has never had.
-- Block validation gains one rule (duplicate wtxids) and one requirement on the
-  *failure path* (do not poison the hash) — the latter being easy to implement and
-  easy to forget, so it belongs in a test rather than only in prose.
-- The tree remains non-injective. Correctness rests on the duplicate check
-  running, which is a weaker guarantee than Option A's structural one, accepted in
-  exchange for computing block hashes the way every Bitcoin reference does.
-- Settles the glossary term **merkle root**.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -133,10 +133,11 @@ Bitcoin · 🅧 deferred out of v1 by [ADR-0001](adr/0001-v1-scope.md).
   blocks that contain duplicate wtxids — and such a rejection must **not** cache
   the block hash as permanently invalid, or the denial of service survives.
 
-  ⚠️ **The code does not do this yet.** `Block::get_merkle_root_hash` currently
-  builds a right-leaning *chain*, not a tree — `H(H(H(d,c),b),a)` for four leaves
-  — and matches Bitcoin only for a single transaction. It has no test pinning its
-  output. See ADR-0010's Correction.
+  ⚠️ **Partly built.** `block::merkle_root` now builds the tree correctly —
+  left-to-right pairing, per-level duplication — pinned by a known-answer test
+  against a real block's published root. Its **leaves are still txids**; they
+  become wtxids with the witness separation in M3, and the duplicate-wtxid
+  rejection needs block validation in M4. See ADR-0010's Correction.
 - **Coinbase** ✅ (ADR-0008) — the block's first transaction, minting subsidy +
   fees. A `Transaction` identified by predicate: one input with a null outpoint.
   Its input carries an **empty Witness** and a `coinbase_data` beginning with the

--- a/src/block.rs
+++ b/src/block.rs
@@ -4,6 +4,34 @@ use crate::util::{get_compact_int, get_hash};
 use anyhow::{anyhow, Context, Result};
 use primitive_types::U256;
 
+/// Bitcoin's merkle construction: pair left to right, level by level,
+/// duplicating the last node wherever a level has an odd count.
+///
+/// Each level is built into a new vector rather than pushed back onto the one
+/// being read — doing the latter feeds a level's own results back into it and
+/// produces a chain, not a tree.
+fn merkle_root(leaves: &[[u8; 32]]) -> Option<[u8; 32]> {
+    if leaves.is_empty() {
+        return None;
+    }
+
+    let mut level = leaves.to_vec();
+
+    while level.len() > 1 {
+        level = level
+            .chunks(2)
+            .map(|pair| {
+                let mut joined = [0u8; 64];
+                joined[..32].copy_from_slice(&pair[0]);
+                joined[32..].copy_from_slice(pair.get(1).unwrap_or(&pair[0]));
+                get_hash(&joined)
+            })
+            .collect();
+    }
+
+    Some(level[0])
+}
+
 #[derive(Clone, Debug)]
 pub struct Block {
     pub version: i32,
@@ -89,29 +117,9 @@ impl Block {
     }
 
     fn get_merkle_root_hash(&self) -> Result<[u8; 32]> {
-        let mut ids: Vec<[u8; 32]> = self.transactions.iter().map(|tx| tx.get_tx_id()).collect();
+        let leaves: Vec<[u8; 32]> = self.transactions.iter().map(|tx| tx.get_tx_id()).collect();
 
-        if ids.is_empty() {
-            return Ok([0u8; 32]);
-        }
-
-        while ids.len() > 1 {
-            let mut count = ids.len();
-
-            while count > 0 {
-                let tx_id_1 = ids.pop().context("Invalid tx_id(1) array")?;
-                count -= 1;
-                let tx_id_2 = match count {
-                    0 => tx_id_1,
-                    _ => ids.pop().context("Invalid tx_id(2) array")?,
-                };
-                let concat = [&tx_id_1[..], &tx_id_2[..]].concat();
-                let hash = get_hash(concat.as_slice());
-                ids.push(hash);
-                count = count.saturating_sub(1);
-            }
-        }
-        Ok(ids[0])
+        merkle_root(&leaves).context("a block needs a transaction to have a merkle root")
     }
 
     pub fn get_raw_format(&self) -> Result<Vec<u8>> {
@@ -172,6 +180,97 @@ mod tests {
     use primitive_types::U256;
     use rstest::rstest;
 
+    /// Hashes are little-endian internally and only reversed for display, so a
+    /// txid copied from a block explorer has to be reversed to be used here.
+    fn leaf(displayed: &str) -> [u8; 32] {
+        let mut bytes: [u8; 32] = decode(displayed).unwrap().try_into().unwrap();
+        bytes.reverse();
+        bytes
+    }
+
+    fn displayed(root: [u8; 32]) -> String {
+        let mut bytes = root;
+        bytes.reverse();
+        encode(bytes)
+    }
+
+    fn node(left: [u8; 32], right: [u8; 32]) -> [u8; 32] {
+        get_hash(&[left, right].concat())
+    }
+
+    #[test]
+    fn the_root_of_a_real_blocks_transactions_matches_its_published_root() {
+        // Bitcoin block 170 — the first payment ever made, Satoshi to Hal
+        // Finney. Two transactions, so this pins pair order as well as hashing.
+        let coinbase = leaf("b1fea52486ce0c62bb442b530a3f0132b826c74e473d1f2c220bfa78111c5082");
+        let payment = leaf("f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16");
+
+        assert_eq!(
+            "7dac2c5666815c17a3b36427de37bb9d2e2c5ccec3f8633eb91a4205cb4c10ff",
+            displayed(merkle_root(&[coinbase, payment]).unwrap())
+        );
+    }
+
+    #[test]
+    fn a_single_transaction_is_its_own_root() {
+        // Bitcoin's genesis block: one transaction, and its merkle root is that
+        // transaction's id unchanged.
+        let coinbase = leaf("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+
+        assert_eq!(coinbase, merkle_root(&[coinbase]).unwrap());
+    }
+
+    #[test]
+    fn four_leaves_pair_left_to_right() {
+        let [a, b, c, d] = [
+            leaf_number(1),
+            leaf_number(2),
+            leaf_number(3),
+            leaf_number(4),
+        ];
+
+        assert_eq!(
+            node(node(a, b), node(c, d)),
+            merkle_root(&[a, b, c, d]).unwrap(),
+            "the root must be H(H(a,b),H(c,d)), not a chain"
+        );
+    }
+
+    #[test]
+    fn an_odd_level_duplicates_its_last_node() {
+        let [a, b, c] = [leaf_number(1), leaf_number(2), leaf_number(3)];
+
+        assert_eq!(
+            node(node(a, b), node(c, c)),
+            merkle_root(&[a, b, c]).unwrap()
+        );
+    }
+
+    #[test]
+    fn duplication_happens_per_level_not_by_padding_the_leaves() {
+        // Six leaves separate the two: per-level gives H(H(ab,cd), H(ef,ef)),
+        // while padding the leaf list out to eight gives H(H(ab,cd), H(ef,ff)).
+        let leaves: Vec<[u8; 32]> = (1..=6).map(leaf_number).collect();
+        let [a, b, c, d, e, f] = <[[u8; 32]; 6]>::try_from(leaves.clone()).unwrap();
+
+        let per_level = node(node(node(a, b), node(c, d)), node(node(e, f), node(e, f)));
+        let padded = node(node(node(a, b), node(c, d)), node(node(e, f), node(f, f)));
+
+        assert_ne!(per_level, padded, "the two constructions must differ here");
+        assert_eq!(per_level, merkle_root(&leaves).unwrap());
+    }
+
+    #[test]
+    fn no_transactions_has_no_root() {
+        assert_eq!(None, merkle_root(&[]));
+    }
+
+    fn leaf_number(n: u8) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        bytes[0] = n;
+        bytes
+    }
+
     #[rstest]
     #[case(1usize)]
     #[case(2usize)]
@@ -180,6 +279,8 @@ mod tests {
     fn mines_generates_correct_hash(#[case] number_of_transactions: usize) {
         let mut block = get_block(number_of_transactions);
 
+        // Only asserts that a nonce was found: any merkle root satisfies this,
+        // so the root itself is pinned by the tests above, not by mining.
         assert!(block.mine().unwrap());
     }
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -4,12 +4,6 @@ use crate::util::{get_compact_int, get_hash};
 use anyhow::{anyhow, Context, Result};
 use primitive_types::U256;
 
-/// Bitcoin's merkle construction: pair left to right, level by level,
-/// duplicating the last node wherever a level has an odd count.
-///
-/// Each level is built into a new vector rather than pushed back onto the one
-/// being read — doing the latter feeds a level's own results back into it and
-/// produces a chain, not a tree.
 fn merkle_root(leaves: &[[u8; 32]]) -> Option<[u8; 32]> {
     if leaves.is_empty() {
         return None;
@@ -17,6 +11,8 @@ fn merkle_root(leaves: &[[u8; 32]]) -> Option<[u8; 32]> {
 
     let mut level = leaves.to_vec();
 
+    // A new vector per level: pushing back into the one being read feeds a
+    // level's results into itself and builds a chain, not a tree.
     while level.len() > 1 {
         level = level
             .chunks(2)
@@ -180,8 +176,8 @@ mod tests {
     use primitive_types::U256;
     use rstest::rstest;
 
-    /// Hashes are little-endian internally and only reversed for display, so a
-    /// txid copied from a block explorer has to be reversed to be used here.
+    // Hashes are little-endian internally, so a txid copied from an explorer
+    // has to be reversed to be used here.
     fn leaf(displayed: &str) -> [u8; 32] {
         let mut bytes: [u8; 32] = decode(displayed).unwrap().try_into().unwrap();
         bytes.reverse();
@@ -200,8 +196,7 @@ mod tests {
 
     #[test]
     fn the_root_of_a_real_blocks_transactions_matches_its_published_root() {
-        // Bitcoin block 170 — the first payment ever made, Satoshi to Hal
-        // Finney. Two transactions, so this pins pair order as well as hashing.
+        // Bitcoin block 170, the first payment ever made. Two transactions.
         let coinbase = leaf("b1fea52486ce0c62bb442b530a3f0132b826c74e473d1f2c220bfa78111c5082");
         let payment = leaf("f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16");
 
@@ -213,8 +208,7 @@ mod tests {
 
     #[test]
     fn a_single_transaction_is_its_own_root() {
-        // Bitcoin's genesis block: one transaction, and its merkle root is that
-        // transaction's id unchanged.
+        // Bitcoin's genesis block.
         let coinbase = leaf("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
 
         assert_eq!(coinbase, merkle_root(&[coinbase]).unwrap());
@@ -248,8 +242,7 @@ mod tests {
 
     #[test]
     fn duplication_happens_per_level_not_by_padding_the_leaves() {
-        // Six leaves separate the two: per-level gives H(H(ab,cd), H(ef,ef)),
-        // while padding the leaf list out to eight gives H(H(ab,cd), H(ef,ff)).
+        // Six is the smallest count where the two differ; they agree at 3 and 5.
         let leaves: Vec<[u8; 32]> = (1..=6).map(leaf_number).collect();
         let [a, b, c, d, e, f] = <[[u8; 32]; 6]>::try_from(leaves.clone()).unwrap();
 
@@ -263,6 +256,39 @@ mod tests {
     #[test]
     fn no_transactions_has_no_root() {
         assert_eq!(None, merkle_root(&[]));
+    }
+
+    /// `get_block` fills itself with identical transactions, which cannot
+    /// detect a reordering. These two differ.
+    fn a_transaction(marker: u64) -> Transaction {
+        let mut transaction = get_tx();
+        transaction.outputs[0].value = 10_000 + marker;
+        transaction
+    }
+
+    #[test]
+    fn a_blocks_leaves_are_its_transaction_ids_in_order() {
+        let first = a_transaction(1);
+        let second = a_transaction(2);
+        let mut block = get_block(0);
+        block.transactions = vec![first.clone(), second.clone()];
+
+        assert_ne!(first.get_tx_id(), second.get_tx_id());
+        assert_eq!(
+            node(first.get_tx_id(), second.get_tx_id()),
+            block.get_merkle_root_hash().unwrap(),
+            "leaves are the transaction ids, in order, and not byte-reversed"
+        );
+    }
+
+    #[test]
+    fn a_block_with_no_transactions_has_no_root_rather_than_zeroes() {
+        let block = get_block(0);
+
+        assert!(
+            block.get_merkle_root_hash().is_err(),
+            "an all-zero root is a value a caller can mistake for a real one"
+        );
     }
 
     fn leaf_number(n: u8) -> [u8; 32] {
@@ -279,8 +305,7 @@ mod tests {
     fn mines_generates_correct_hash(#[case] number_of_transactions: usize) {
         let mut block = get_block(number_of_transactions);
 
-        // Only asserts that a nonce was found: any merkle root satisfies this,
-        // so the root itself is pinned by the tests above, not by mining.
+        // Asserts only that a nonce was found; any root satisfies that.
         assert!(block.mine().unwrap());
     }
 


### PR DESCRIPTION
Part of #31 — the construction. **Three** of its criteria are blocked on work that does not exist yet; they are spelled out at the bottom and now tracked in #38 rather than quietly ticked.

(No auto-close keyword: #31 has three unmet criteria, one of which leaves the CVE-2012-2459 exposure open.)

## The defect

`get_merkle_root_hash` pushed each hash back onto the vector it was popping from, so a level's own results were consumed again in the same pass:

| leaves | produced | Bitcoin produces |
|---|---|---|
| 4 | `H(H(H(d,c),b),a)` — a right-leaning chain | `H(H(a,b),H(c,d))` |

They agreed only for a single transaction. Each level is now built into a **new** vector, paired left to right, duplicating the last node wherever a *level* has an odd count.

## Why it survived, and what that dictated about the tests

The function had **no test pinning its output**:

- `prepare_for_mining` *requires* a root rather than computing one, so `block_generates_correct_hash` — which pins Bitcoin's real genesis hash and looks like the strongest test in the file — passes the fixture's hardcoded root straight through and never calls it.
- `mines_generates_correct_hash` does call it, but asserts only that a nonce was found. **Any** root satisfies that. I left it in place with a comment saying so rather than pretending it covers more.

So the new tests are known-answer wherever possible, not self-consistency:

| test | pins |
|---|---|
| `the_root_of_a_real_blocks_transactions_matches_its_published_root` | Bitcoin **block 170** — the first payment ever made — two transactions against that block's published root. Pins pair order and hashing together |
| `a_single_transaction_is_its_own_root` | Genesis: one transaction, root is its txid unchanged |
| `four_leaves_pair_left_to_right` | `H(H(a,b),H(c,d))` asserted directly against the definition |
| `an_odd_level_duplicates_its_last_node` | `H(H(a,b),H(c,c))` |
| `duplication_happens_per_level_not_by_padding_the_leaves` | **six** leaves — see below |
| `no_transactions_has_no_root` | empty input returns `None`, replacing a silent all-zero root |

Six leaves is deliberate. Per-level duplication and "pad the leaf list to a power of two" give the *same* answer at three and five; six is the smallest count where they diverge (`H(ef,ef)` vs `H(ef,ff)`). A smaller odd case would have looked like coverage without being any.

I verified the block-170 fixture before using it rather than trusting recall — the two txids and the published root hash consistently, which three independently-wrong values could not.

## Mutations

| revert | outcome |
|---|---|
| the original chain algorithm | **4 failed** — including the 2-leaf known-answer, confirming they differ from n=2 |
| pair order reversed | 4 failed |
| odd node paired with zeroes instead of duplicated | 2 failed, exactly the odd-count tests |
| empty-input guard removed | 1 failed (panic, not a zero root) |

That first row is the ticket's own acceptance criterion: *"The tests fail against the current implementation — check by keeping them and reverting the algorithm."*

## Deliberately not done

Three criteria on #31 need infrastructure that isn't built. They are tracked in **#38**, together with a 64-byte-transaction finding from this PR's security review:

- **Leaves are still txids.** They become wtxids with witness separation in M3 (ADR-0003). The algorithm is indifferent to which hash it's handed, so this really is the one-line leaf change the ADR originally described — the tree was the hard part.
- **Duplicate-wtxid rejection**, and the rule that such a rejection must not cache the block hash as permanently invalid, are block *validation* — M4. There is no validation path to add them to. **The CVE-2012-2459 exposure they close is therefore still open**, and stays tracked on the milestone.

ADR-0010's Correction section, the glossary's ⚠️ on **Merkle root**, and ARCHITECTURE's module map all said this code was broken. All three updated to say what is now true and what is still outstanding.

One new dead-code warning (`merkle_root` is never reached from `main`, since the whole `Block` path is unwired) — same honest signal as the other 13, so no `#[allow]`.

Green: 116 unit, 22 functional. Independent of #36 — no shared files.
