### PR TITLE
A connection proves who it is before it counts as a peer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ CI (`.github/workflows/tests.yml`) runs both suites on pushes/PRs to `main`, as 
 
 - `config.toml` is optional, and so is every field in it. A file that is present but unparseable, or that contains an unknown key, is a startup error rather than a silent fallback.
 - Addresses are parsed into `SocketAddr` **at this boundary**, so a malformed address fails at startup naming the field and value, instead of panicking later inside whichever thread first tried to bind or dial.
+- One value is written back *after* resolution: `main` replaces `host_address` with the address the listener actually bound. `:0` asks the OS to choose a port, and the chosen one is what `version` must advertise for a peer to dial us back.
 - With no `config.toml` and no arguments the node listens on `127.0.0.1:34352` with no peers, which is a valid standalone node — others can dial it.
 - The repo's checked-in `config.toml` points `host_address` and `addresses_to_connect` at the same loopback address, so a single node connects to *itself* and exercises the ping/pong exchange.
 
@@ -92,8 +93,10 @@ The node is a small P2P server modeled on Bitcoin's message framing. `main.rs` b
 `spawn_connection` registers the peer in `node.peers` before handing off, and a `Registered` guard removes it on any exit including a panic. A refused connection (`MAX_PEERS`, or an address already dialled) is dropped there and never becomes a thread pair.
 
 Each connection then runs `handle_connection`, which splits into **two threads** over `try_clone()`d socket handles, joined by a *bounded* `sync_channel` of already-framed bytes:
-- the **reader** blocks in `read` with no timeout, appends to a growing `recv_buffer`, drains complete messages out of it, and *enqueues* replies (Ping → Pong) rather than writing them;
-- the **writer** owns every write. It drains the channel with `recv_timeout`, and that timeout *is* the ping timer — a `Ping` goes out every `PING_INTERVAL` (11s) whatever the reader is doing, first ping immediately. The interval is a parameter of `write_loop`, so tests use milliseconds.
+- the **reader** blocks in `read` under the handshake timeout, appends to a growing `recv_buffer`, drains complete messages out of it, and *enqueues* replies (Ping → Pong, Version → Verack) rather than writing them;
+- the **writer** owns every write. Its first is our `version`, passed in rather than queued so nothing can precede it. Then it drains the channel with `recv_timeout`, and that timeout *is* the ping timer — a `Ping` goes out every `PING_INTERVAL` (11s) whatever the reader is doing, first ping immediately. The interval is a parameter of `write_loop`, so tests use milliseconds.
+
+A peer is **Ready** only once its `version` and `verack` have both arrived; the state lives on `PeerHandle` and advances in one order, once. `HANDSHAKE_TIMEOUT` (20s) is an absolute deadline checked on every turn of the read loop — not a per-read timeout, which a peer sending legal traffic would reset forever. Nothing is gated on Ready yet: pings and pongs still flow mid-handshake.
 
 Nothing calls `println!` outside `node::record`, which prints **and** appends to a bounded `Log` on the shared node — M6's HTTP API reads it. It prints *before* taking the lock: stdout is a blocking syscall, and holding the node across it would stall every peer behind a pipe nobody drains, which is the same rule `broadcast` follows with `try_send`. A poisoned lock is recovered rather than propagated, because logging must not be the thing that kills a thread.
 
@@ -104,6 +107,7 @@ Nothing calls `println!` outside `node::record`, which prints **and** appends to
 The two ends share a fate: the reader ending releases the registration — **before** the join, or the table's sender keeps the writer alive — and the writer ending shuts the socket down, which unblocks the reader.
 
 **Message framing (`src/messages/`)** is the core of the wire protocol:
+- Built so far: `ping` / `pong` (an 8-byte nonce each), `version` (30 bytes: protocol version, node nonce, and a fixed-width IPv6-with-IPv4-mapped listen address), and `verack` (empty).
 - `Message<T>` = `Header` (24 bytes) + typed `payload: T`. The header is 4 magic bytes (`0xf9beb4d9`), a 12-byte command name, a 4-byte little-endian payload size, and a 4-byte checksum (first 4 bytes of the double-SHA256 of the payload).
 - Any payload type implements the `Payload` trait (`get_raw_format`, `get_command_name`); adding a new message type means adding a `Payload` impl and a new variant + command-name arm in `MessageReceived` (`message.rs`).
 - `MessageReceived::try_parse_message` is designed for streamed TCP data: it returns `(None, 0)` when the buffer holds only a partial message (so the caller keeps reading), and otherwise returns the parsed message and the number of bytes consumed. It validates magic bytes, enforces `MAX_PAYLOAD_SIZE` (32 MiB), and verifies the checksum before dispatching by command name.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -163,7 +163,7 @@ These hold everywhere and are not up for per-module negotiation:
 |---|---|---|
 | `byte_reader.rs` | Bounds-checked deserialization cursor | Built |
 | `util.rs` | HASH256, compact-size | Built |
-| `config.rs` | Resolves configuration and validates addresses into `SocketAddr`; `resolve` is the canonical statement of precedence | Built |
+| `config.rs` | Resolves configuration and validates addresses into `SocketAddr`; `resolve` is the canonical statement of precedence. One value is written back after it: `main` replaces `host_address` with the address the listener bound, since `:0` asks the OS to choose and `version` must advertise the choice | Built |
 | `messages/` | `Header`, `Message<T>`, `Payload` trait, `MessageReceived` dispatch | Built (ping/pong, version/verack) |
 | `protocol.rs` | Per-connection reader and writer threads; the writer drives the ping timer | Built |
 | `block.rs` | Header assembly, merkle construction, target math, `mine()` | Built — tree is correct (ADR-0010); leaves become wtxids with ADR-0003 in M3; not wired to the node |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,10 +28,11 @@ struct Node {
     chain:   Blockchain,   // block index, best tip, height map, cumulative work
     utxo:    UtxoSet,      // Outpoint -> (value, locking commitment)
     mempool: Mempool,      // txid -> Transaction
-    peers:   PeerTable,    // PeerId -> PeerHandle { address, origin, tx: SyncSender<Vec<u8>> }
+    peers:   PeerTable,    // PeerId -> PeerHandle { address, origin, handshake, tx: SyncSender<Vec<u8>> }
     wallet:  Wallet,
     config:  Config,
     log:     Log,          // bounded ring; every entry also goes to stdout
+    nonce:   u64,          // minted per run; how a node recognises itself on the wire
 }
 type SharedNode = Arc<Mutex<Node>>;
 ```
@@ -49,7 +50,8 @@ Threads and channels. **No async runtime** — see
 Per connection, **two threads**:
 
 - a **reader** — blocking `read` loop → append to buffer → drain complete
-  messages → dispatch;
+  messages → dispatch. Its read timeout is the handshake's, so a peer that
+  connects and then says nothing wakes it rather than parking it forever;
 - a **writer** — drains a `Receiver<Vec<u8>>` into the socket, and drives the
   ping timer via `recv_timeout`.
 
@@ -100,8 +102,33 @@ The two threads share a fate, in both directions. The reader ending releases the
 registration — before joining the writer, or the sender it holds would keep the
 writer alive forever — so the writer sees `Disconnected` and stops. The writer
 ending drops the write half, whose `Drop` shuts the socket down and wakes the
-reader out of a `read` that has no timeout. Neither can outlive the other, and
-neither can outlive its entry in the table.
+reader, which on an established connection would otherwise sit out its full read
+timeout. Neither can outlive the other, and neither can outlive its entry in the
+table.
+
+### The handshake
+
+A connection is not a peer until both sides have identified themselves. The
+writer's **first** write is our `version` — ahead of the outbound queue, not in
+it, so nothing we enqueue can precede the message that says who is speaking. A
+received `version` is answered with a `verack`, and the peer is **Ready** once
+both of theirs have arrived: `AwaitingVersion → AwaitingVerack → Ready`, on
+`PeerHandle`.
+
+The state advances only on what the *peer* sends, and only in that order. A
+`verack` before any `version`, or a second `version` after Ready, ends the
+connection — a handshake happens once, and treating a repeat as a fresh one is
+how a peer resets whatever the handshake was gating.
+
+`HANDSHAKE_TIMEOUT` (20s) is an **absolute deadline**, checked on every turn of
+the read loop rather than only when a read expires: a peer that dribbles legal
+traffic it never completes a handshake with keeps the read returning, and a
+per-read timeout would never fire on it. Failing it ends the connection through
+the same path as any other read error, so the slot and the `recv_buffer` go with
+it.
+
+Relay is **not** yet gated on Ready: the keep-alive ping and the pong that
+answers one still go out mid-handshake. That gate is its own change.
 
 The miner is one more thread, holding no lock while it grinds: it snapshots the
 mempool, builds a candidate block, releases the lock, and only re-acquires it to
@@ -137,7 +164,7 @@ These hold everywhere and are not up for per-module negotiation:
 | `byte_reader.rs` | Bounds-checked deserialization cursor | Built |
 | `util.rs` | HASH256, compact-size | Built |
 | `config.rs` | Resolves configuration and validates addresses into `SocketAddr`; `resolve` is the canonical statement of precedence | Built |
-| `messages/` | `Header`, `Message<T>`, `Payload` trait, `MessageReceived` dispatch | Built (ping/pong) |
+| `messages/` | `Header`, `Message<T>`, `Payload` trait, `MessageReceived` dispatch | Built (ping/pong, version/verack) |
 | `protocol.rs` | Per-connection reader and writer threads; the writer drives the ping timer | Built |
 | `block.rs` | Header assembly, merkle construction, target math, `mine()` | Built — tree is correct (ADR-0010); leaves become wtxids with ADR-0003 in M3; not wired to the node |
 | `transaction.rs` | `Transaction` / `TxIn` / `TxOut` / `Outpoint` / `Witness`, dual serialization | Built — reshaped by ADR-0003/0008/0011 |
@@ -145,7 +172,7 @@ These hold everywhere and are not up for per-module negotiation:
 | `block_storage.rs` | `blocks.dat` / `undo.dat` framing and offset reads | Empty stub (ADR-0013) |
 | `script.rs` | Opcodes, stack, interpreter, resource limits | Not built (ADR-0002) |
 | `address.rs` | Base58Check — display edge only | Not built (ADR-0005) |
-| `node.rs` | `Node` / `SharedNode`, `PeerTable`, `send_to` / `broadcast`, the `Log` | Built — nothing broadcasts until relay lands in M3; the log has no reader until M6 |
+| `node.rs` | `Node` / `SharedNode`, `PeerTable`, the `Handshake` state machine, `send_to` / `broadcast`, the `Log` | Built — nothing broadcasts until relay lands in M3; the log has no reader until M6 |
 | `blockchain.rs` | Block index, cumulative work, multiple tips, connect/disconnect, reorg | Not built (ADR-0012) |
 | `difficulty.rs` | Per-block retarget, timestamp rules | Not built (ADR-0009) |
 | `utxo.rs` | `Outpoint` → output set, backed by the KV store | Not built |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -179,7 +179,8 @@ Bitcoin · 🅧 deferred out of v1 by [ADR-0001](adr/0001-v1-scope.md).
 - **SharedNode** ✅ — `Arc<Mutex<Node>>` central state, handed to every connection
   thread. Built (M1); holds `Config` and the `PeerTable` so far.
 - **PeerTable / PeerHandle** ✅ — the peer registry: `PeerId` → `PeerHandle`
-  (`address`, `origin`, and the peer's **only** outbound sender). Built (M1).
+  (`address`, `origin`, `handshake`, and the peer's **only** outbound sender).
+  Built (M1; `handshake` in M2).
   Holding the only sender is what makes removal a disconnect rather than
   bookkeeping — see [ARCHITECTURE](ARCHITECTURE.md#concurrency-model).
 - **PeerId** ✅ — a peer's identity *within one node's run*, assigned on
@@ -187,7 +188,24 @@ Bitcoin · 🅧 deferred out of v1 by [ADR-0001](adr/0001-v1-scope.md).
   between nodes; it is a table key, never anything on the wire.
 - **Origin** ✅ — whether we **dialled** a peer or **accepted** it. Dedup is on
   dialled addresses only: an accepted connection shows an ephemeral source port,
-  so the same peer looks like two until M2's version nonce identifies it.
+  so the same peer looks like two until the version nonce identifies it.
+- **version** ✅ — the message a connection opens with: `protocol_version` (u32),
+  the sender's **node nonce** (u64), and the address it listens on (16 bytes of
+  IPv6 with IPv4 mapped in, then a u16 port — one fixed-width field for both
+  families). 30 bytes. What a peer advertises is the address it **bound**, not
+  the one it was configured with, because `:0` asks the OS to choose.
+- **verack** ✅ — the empty-payload answer to a `version`. One carrying a body is
+  refused: it is not a message this node speaks.
+- **Node nonce** ✅ — minted once per process run and carried in every `version`.
+  It is what tells a node it has dialled *itself*, and what identifies one peer
+  behind two connections — neither of which an address can do.
+- **Handshake** ✅ — the per-peer state on `PeerHandle`:
+  `AwaitingVersion → AwaitingVerack → Ready`, advanced only by *their* messages.
+  It happens once and in one order: a `verack` before any `version`, or a second
+  `version` after Ready, is a protocol error that ends the connection rather than
+  starting a new handshake. A connection that has not reached Ready within
+  `HANDSHAKE_TIMEOUT` (20s) is dropped — an absolute deadline, so a peer that
+  dribbles bytes it never completes a handshake with cannot hold a slot open.
 - **MAX_PEERS / OUTBOUND_QUEUE** ✅ — 32 connections, 128 queued messages each.
   At either limit the peer is **refused** or **dropped**, never made to wait: a
   blocking send would stall the whole node on one slow socket.
@@ -198,8 +216,10 @@ Bitcoin · 🅧 deferred out of v1 by [ADR-0001](adr/0001-v1-scope.md).
   place the node prints, and it prints **before** taking the lock — stdout is a
   blocking syscall, and holding the node across it would stall every peer behind
   a slow pipe.
-- **Ready peer** ✅ — a peer that has completed version/verack; only Ready peers
-  are relayed to. Not yet built (M2).
+- **Ready peer** ✅ — a peer whose `Handshake` has reached `Ready`, meaning both
+  its `version` and its `verack` have arrived. Built (M2). Gating relay on it is
+  separate work — today the keep-alive ping and the pong that answers one still
+  go out mid-handshake.
 - **Reorg** ✅ (ADR-0012) — switching to a heavier branch. Disconnect back to the
   fork point restoring outputs from each block's **undo record**, then connect
   forward. Cost is proportional to reorg *depth*, not chain height. Not optional:

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,12 @@ fn main() -> Result<()> {
     let listener = TcpListener::bind(host_address)
         .with_context(|| format!("could not listen on {host_address}"))?;
 
-    record(&node, format!("Listening on {}", listener.local_addr()?));
+    // Port 0 asks the OS to pick, so only the bound address is one a peer could
+    // dial us back on — and that is what `version` advertises.
+    let host_address = listener.local_addr()?;
+    node.lock().expect("node lock poisoned").config.host_address = host_address;
+
+    record(&node, format!("Listening on {host_address}"));
 
     if addresses_to_connect.is_empty() {
         record(

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -1,6 +1,8 @@
 use crate::byte_reader::ByteReader;
 use crate::messages::ping::{Ping, PING_COMMAND_NAME};
 use crate::messages::pong::{Pong, PONG_COMMAND_NAME};
+use crate::messages::verack::{Verack, VERACK_COMMAND_NAME};
+use crate::messages::version::{Version, VERSION_COMMAND_NAME};
 use crate::util::{get_hash, parse_command_12};
 use anyhow::{anyhow, Result};
 
@@ -31,6 +33,8 @@ pub trait Payload {
 pub enum MessageReceived {
     PingMessage(Message<Ping>),
     PongMessage(Message<Pong>),
+    VersionMessage(Message<Version>),
+    VerackMessage,
 }
 
 impl Header {
@@ -150,6 +154,16 @@ impl MessageReceived {
                 header,
                 payload: Pong::parse_raw_format(bytes)?,
             }),
+            VERSION_COMMAND_NAME => MessageReceived::VersionMessage(Message {
+                header,
+                payload: Version::parse_raw_format(bytes)?,
+            }),
+            VERACK_COMMAND_NAME => {
+                // Parsed for its refusal, not its value: a verack is the fact
+                // of its arrival, and one carrying a body is not one of ours.
+                Verack::parse_raw_format(bytes)?;
+                MessageReceived::VerackMessage
+            }
             _ => return Err(anyhow!("Unknown command: {}", command_name)),
         };
 

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -1,3 +1,5 @@
 pub mod message;
 pub mod ping;
 pub mod pong;
+pub mod verack;
+pub mod version;

--- a/src/messages/verack.rs
+++ b/src/messages/verack.rs
@@ -1,0 +1,47 @@
+use crate::messages::message::Payload;
+use crate::util::command_12;
+use anyhow::{anyhow, Result};
+
+pub const VERACK_COMMAND_NAME: &str = "verack";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Verack;
+
+impl Verack {
+    pub fn parse_raw_format(bytes: Vec<u8>) -> Result<Verack> {
+        if !bytes.is_empty() {
+            return Err(anyhow!("verack carries no payload, got {} bytes", bytes.len()));
+        }
+
+        Ok(Verack)
+    }
+}
+
+impl Payload for Verack {
+    fn get_raw_format(&self) -> Result<Vec<u8>> {
+        Ok(Vec::new())
+    }
+
+    fn get_command_name(&self) -> [u8; 12] {
+        command_12(VERACK_COMMAND_NAME)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_verack_survives_a_round_trip() {
+        let raw = Verack.get_raw_format().unwrap();
+
+        assert!(raw.is_empty());
+        assert_eq!(Verack, Verack::parse_raw_format(raw).unwrap());
+    }
+
+    #[test]
+    fn a_verack_carrying_a_payload_is_refused() {
+        Verack::parse_raw_format(vec![0])
+            .expect_err("a verack with a body is not a verack this node understands");
+    }
+}

--- a/src/messages/version.rs
+++ b/src/messages/version.rs
@@ -1,12 +1,12 @@
 use crate::byte_reader::ByteReader;
 use crate::messages::message::Payload;
 use crate::util::command_12;
-use anyhow::Result;
-use rand::Rng;
+use anyhow::{anyhow, Result};
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 
 pub const VERSION_COMMAND_NAME: &str = "version";
 pub const PROTOCOL_VERSION: u32 = 1;
+pub const VERSION_PAYLOAD_LENGTH: usize = 30;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Version {
@@ -25,6 +25,13 @@ impl Version {
     }
 
     pub fn parse_raw_format(bytes: Vec<u8>) -> Result<Version> {
+        if bytes.len() != VERSION_PAYLOAD_LENGTH {
+            return Err(anyhow!(
+                "a version is {VERSION_PAYLOAD_LENGTH} bytes, got {}",
+                bytes.len()
+            ));
+        }
+
         let mut reader = ByteReader::new(&bytes);
 
         Ok(Version {
@@ -50,12 +57,7 @@ impl Payload for Version {
     }
 }
 
-pub fn a_nonce() -> u64 {
-    rand::rng().next_u64()
-}
-
-// Always 16 bytes plus a port, IPv4 mapped into IPv6, so the field is fixed
-// width and a v4 peer and a v6 peer parse through the same path.
+// IPv4 mapped into IPv6, so a v4 peer and a v6 peer parse through one path.
 fn write_address(address: SocketAddr) -> [u8; 18] {
     let mut out = [0u8; 18];
 
@@ -129,7 +131,13 @@ mod tests {
     }
 
     #[test]
-    fn nonces_differ_between_runs() {
-        assert_ne!(a_nonce(), a_nonce());
+    fn a_version_with_bytes_to_spare_is_refused_rather_than_truncated() {
+        let mut padded = Version::new(1, "127.0.0.1:1".parse().unwrap())
+            .get_raw_format()
+            .unwrap();
+        padded.push(0);
+
+        Version::parse_raw_format(padded)
+            .expect_err("a version is a fixed 30 bytes, and something longer is not one");
     }
 }

--- a/src/messages/version.rs
+++ b/src/messages/version.rs
@@ -1,0 +1,135 @@
+use crate::byte_reader::ByteReader;
+use crate::messages::message::Payload;
+use crate::util::command_12;
+use anyhow::Result;
+use rand::Rng;
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+
+pub const VERSION_COMMAND_NAME: &str = "version";
+pub const PROTOCOL_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Version {
+    pub protocol_version: u32,
+    pub nonce: u64,
+    pub listen_address: SocketAddr,
+}
+
+impl Version {
+    pub fn new(nonce: u64, listen_address: SocketAddr) -> Self {
+        Version {
+            protocol_version: PROTOCOL_VERSION,
+            nonce,
+            listen_address,
+        }
+    }
+
+    pub fn parse_raw_format(bytes: Vec<u8>) -> Result<Version> {
+        let mut reader = ByteReader::new(&bytes);
+
+        Ok(Version {
+            protocol_version: reader.read_u32()?,
+            nonce: reader.read_u64()?,
+            listen_address: read_address(&mut reader)?,
+        })
+    }
+}
+
+impl Payload for Version {
+    fn get_raw_format(&self) -> Result<Vec<u8>> {
+        let mut raw_format = Vec::new();
+        raw_format.extend_from_slice(&self.protocol_version.to_le_bytes());
+        raw_format.extend_from_slice(&self.nonce.to_le_bytes());
+        raw_format.extend_from_slice(&write_address(self.listen_address));
+
+        Ok(raw_format)
+    }
+
+    fn get_command_name(&self) -> [u8; 12] {
+        command_12(VERSION_COMMAND_NAME)
+    }
+}
+
+pub fn a_nonce() -> u64 {
+    rand::rng().next_u64()
+}
+
+// Always 16 bytes plus a port, IPv4 mapped into IPv6, so the field is fixed
+// width and a v4 peer and a v6 peer parse through the same path.
+fn write_address(address: SocketAddr) -> [u8; 18] {
+    let mut out = [0u8; 18];
+
+    let ip = match address.ip() {
+        IpAddr::V4(v4) => v4.to_ipv6_mapped(),
+        IpAddr::V6(v6) => v6,
+    };
+
+    out[..16].copy_from_slice(&ip.octets());
+    out[16..].copy_from_slice(&address.port().to_le_bytes());
+    out
+}
+
+fn read_address(reader: &mut ByteReader) -> Result<SocketAddr> {
+    let mapped = Ipv6Addr::from(reader.read_array::<16>()?);
+    let port = reader.read_u16()?;
+
+    let ip = match mapped.to_ipv4_mapped() {
+        Some(v4) => IpAddr::V4(v4),
+        None => IpAddr::V6(mapped),
+    };
+
+    Ok(SocketAddr::new(ip, port))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::loopback("127.0.0.1:34352")]
+    #[case::any_v4("0.0.0.0:1")]
+    #[case::highest_port("192.168.1.10:65535")]
+    #[case::v6_loopback("[::1]:34352")]
+    #[case::v6_full("[2001:db8::dead:beef]:8333")]
+    fn a_version_survives_a_round_trip(#[case] listen_address: &str) {
+        let original = Version::new(0xdead_beef_cafe_f00d, listen_address.parse().unwrap());
+
+        let parsed = Version::parse_raw_format(original.get_raw_format().unwrap()).unwrap();
+
+        assert_eq!(original, parsed);
+        assert_eq!(listen_address.parse::<SocketAddr>().unwrap(), parsed.listen_address);
+    }
+
+    #[test]
+    fn a_v4_address_does_not_come_back_as_a_mapped_v6_one() {
+        let original = Version::new(1, "127.0.0.1:34352".parse().unwrap());
+
+        let parsed = Version::parse_raw_format(original.get_raw_format().unwrap()).unwrap();
+
+        assert!(
+            parsed.listen_address.is_ipv4(),
+            "a v4 peer must not become v6 by round-tripping, or it will never match a dialled address"
+        );
+    }
+
+    #[test]
+    fn a_truncated_version_is_refused_rather_than_filled_in() {
+        let complete = Version::new(1, "127.0.0.1:1".parse().unwrap())
+            .get_raw_format()
+            .unwrap();
+
+        for length in 0..complete.len() {
+            assert!(
+                Version::parse_raw_format(complete[..length].to_vec()).is_err(),
+                "{length} of {} bytes should not parse",
+                complete.len()
+            );
+        }
+    }
+
+    #[test]
+    fn nonces_differ_between_runs() {
+        assert_ne!(a_nonce(), a_nonce());
+    }
+}

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use rand::Rng;
 use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::sync::mpsc::{SyncSender, TrySendError};
@@ -16,8 +17,6 @@ pub enum Origin {
     Accepted,
 }
 
-/// Both sides send `version` on connect and answer one with `verack`, so a peer
-/// is Ready only once both of theirs have arrived.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Handshake {
     #[default]
@@ -226,7 +225,7 @@ impl Node {
             config,
             peers: PeerTable::default(),
             log: Log::default(),
-            nonce: crate::messages::version::a_nonce(),
+            nonce: rand::rng().next_u64(),
         }))
     }
 }
@@ -514,6 +513,15 @@ mod tests {
             .register(address(5000), Origin::Accepted, outbound)
             .is_ok());
         assert_eq!(2, table.len());
+    }
+
+    #[test]
+    fn each_node_mints_its_own_nonce() {
+        assert_ne!(
+            Node::shared(config()).lock().unwrap().nonce,
+            Node::shared(config()).lock().unwrap().nonce,
+            "a shared nonce cannot tell a self-connection from a peer"
+        );
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -16,10 +16,45 @@ pub enum Origin {
     Accepted,
 }
 
+/// Both sides send `version` on connect and answer one with `verack`, so a peer
+/// is Ready only once both of theirs have arrived.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Handshake {
+    #[default]
+    AwaitingVersion,
+    AwaitingVerack,
+    Ready,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HandshakeEvent {
+    Version,
+    Verack,
+}
+
+impl Handshake {
+    pub fn advance(self, event: HandshakeEvent) -> Result<Handshake, anyhow::Error> {
+        match (self, event) {
+            (Handshake::AwaitingVersion, HandshakeEvent::Version) => Ok(Handshake::AwaitingVerack),
+            (Handshake::AwaitingVerack, HandshakeEvent::Verack) => Ok(Handshake::Ready),
+            (Handshake::AwaitingVersion, HandshakeEvent::Verack) => {
+                Err(anyhow::anyhow!("verack before any version"))
+            }
+            (_, HandshakeEvent::Version) => Err(anyhow::anyhow!("version after the handshake")),
+            (_, HandshakeEvent::Verack) => Err(anyhow::anyhow!("verack after the handshake")),
+        }
+    }
+
+    pub fn is_ready(self) -> bool {
+        self == Handshake::Ready
+    }
+}
+
 #[derive(Debug)]
 pub struct PeerHandle {
     pub address: SocketAddr,
     pub origin: Origin,
+    pub handshake: Handshake,
     outbound: SyncSender<Vec<u8>>,
 }
 
@@ -57,6 +92,7 @@ impl PeerTable {
             PeerHandle {
                 address,
                 origin,
+                handshake: Handshake::default(),
                 outbound,
             },
         );
@@ -80,6 +116,26 @@ impl PeerTable {
 
     pub fn is_empty(&self) -> bool {
         self.peers.is_empty()
+    }
+
+    /// Read and write in one lock: the transition depends on the current state,
+    /// so splitting it would let two messages race the same peer forward.
+    pub fn advance_handshake(
+        &mut self,
+        id: PeerId,
+        event: HandshakeEvent,
+    ) -> Result<Handshake, anyhow::Error> {
+        let peer = self
+            .peers
+            .get_mut(&id)
+            .ok_or_else(|| anyhow::anyhow!("no such peer"))?;
+
+        peer.handshake = peer.handshake.advance(event)?;
+        Ok(peer.handshake)
+    }
+
+    pub fn handshake_of(&self, id: PeerId) -> Option<Handshake> {
+        self.peers.get(&id).map(|peer| peer.handshake)
     }
 
     pub fn ids(&self) -> Vec<PeerId> {
@@ -160,6 +216,8 @@ pub struct Node {
     pub config: Config,
     pub peers: PeerTable,
     pub log: Log,
+    /// Minted once per run so a node can recognise a connection to itself.
+    pub nonce: u64,
 }
 
 impl Node {
@@ -168,6 +226,7 @@ impl Node {
             config,
             peers: PeerTable::default(),
             log: Log::default(),
+            nonce: crate::messages::version::a_nonce(),
         }))
     }
 }
@@ -193,6 +252,7 @@ pub fn record(node: &SharedNode, entry: impl Into<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use std::sync::mpsc::{sync_channel, Receiver};
     use std::thread;
 
@@ -454,6 +514,53 @@ mod tests {
             .register(address(5000), Origin::Accepted, outbound)
             .is_ok());
         assert_eq!(2, table.len());
+    }
+
+    #[test]
+    fn a_peer_counts_only_once_both_sides_have_identified_themselves() {
+        let mut table = PeerTable::default();
+        let (id, _queued) = a_peer(&mut table, 5000);
+
+        assert_eq!(Some(Handshake::AwaitingVersion), table.handshake_of(id));
+
+        assert_eq!(
+            Handshake::AwaitingVerack,
+            table
+                .advance_handshake(id, HandshakeEvent::Version)
+                .unwrap(),
+            "their version is half of it: ours is still unanswered"
+        );
+        assert_eq!(
+            Handshake::Ready,
+            table.advance_handshake(id, HandshakeEvent::Verack).unwrap()
+        );
+        assert!(table.handshake_of(id).unwrap().is_ready());
+    }
+
+    #[rstest]
+    #[case::verack_first(Handshake::AwaitingVersion, HandshakeEvent::Verack)]
+    #[case::two_versions(Handshake::AwaitingVerack, HandshakeEvent::Version)]
+    #[case::two_veracks(Handshake::Ready, HandshakeEvent::Verack)]
+    #[case::version_after_ready(Handshake::Ready, HandshakeEvent::Version)]
+    fn a_handshake_out_of_order_is_refused_rather_than_restarted(
+        #[case] state: Handshake,
+        #[case] event: HandshakeEvent,
+    ) {
+        state
+            .advance(event)
+            .expect_err("the handshake happens once, in one order");
+    }
+
+    #[test]
+    fn a_peer_that_left_the_table_cannot_advance_a_handshake() {
+        let mut table = PeerTable::default();
+        let (id, _queued) = a_peer(&mut table, 5000);
+        table.remove(id);
+
+        assert!(table
+            .advance_handshake(id, HandshakeEvent::Version)
+            .is_err());
+        assert_eq!(None, table.handshake_of(id));
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,8 +1,14 @@
-use crate::messages::message::MessageReceived::{PingMessage, PongMessage};
+use crate::messages::message::MessageReceived::{
+    PingMessage, PongMessage, VerackMessage, VersionMessage,
+};
 use crate::messages::message::{Message, MessageReceived};
 use crate::messages::ping::Ping;
 use crate::messages::pong::Pong;
-use crate::node::{record, Origin, PeerId, Refused, SharedNode, OUTBOUND_QUEUE};
+use crate::messages::verack::Verack;
+use crate::messages::version::Version;
+use crate::node::{
+    record, Handshake, HandshakeEvent, Origin, PeerId, Refused, SharedNode, OUTBOUND_QUEUE,
+};
 use anyhow::{anyhow, Result};
 use std::io::{ErrorKind, Read, Write};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
@@ -17,6 +23,11 @@ const PING_INTERVAL: Duration = Duration::from_secs(11);
 /// Without it `write_all` blocks forever on a socket whose peer stopped
 /// reading, and no amount of dropping the peer elsewhere can end that.
 const WRITE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long a connection may go without identifying itself. It doubles as the
+/// read half's timeout, so a peer that connects and then says nothing wakes the
+/// reader at all rather than parking it against a deadline it cannot see.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
 
 pub fn connect(addr: SocketAddr, node: SharedNode) -> Result<()> {
     let stream = TcpStream::connect(addr)?;
@@ -63,7 +74,7 @@ fn spawn_connection(stream: TcpStream, node: SharedNode, origin: Origin) {
             }
         };
 
-        if let Err(e) = handle_connection(stream, peer, registered, queued) {
+        if let Err(e) = handle_connection(stream, registered, queued) {
             record(&node, format!("Connection with {peer} ended: {e:#}"));
         }
     });
@@ -72,6 +83,7 @@ fn spawn_connection(stream: TcpStream, node: SharedNode, origin: Origin) {
 struct Registered {
     node: SharedNode,
     id: PeerId,
+    address: SocketAddr,
 }
 
 impl Registered {
@@ -90,6 +102,7 @@ impl Registered {
         Ok(Registered {
             node: Arc::clone(node),
             id,
+            address: peer,
         })
     }
 
@@ -111,6 +124,23 @@ impl Registered {
             Err(anyhow!("peer cannot keep up with its own replies"))
         }
     }
+
+    fn advance_handshake(&self, event: HandshakeEvent) -> Result<Handshake> {
+        self.node
+            .lock()
+            .expect("node lock poisoned")
+            .peers
+            .advance_handshake(self.id, event)
+    }
+
+    fn is_ready(&self) -> bool {
+        self.node
+            .lock()
+            .expect("node lock poisoned")
+            .peers
+            .handshake_of(self.id)
+            .is_some_and(Handshake::is_ready)
+    }
 }
 
 impl Drop for Registered {
@@ -126,31 +156,34 @@ struct ShutdownOnDrop(TcpStream);
 
 impl Drop for ShutdownOnDrop {
     fn drop(&mut self) {
-        // The reader parks in read() with no timeout; only a shutdown wakes it.
+        // The reader's own timeout is the handshake's, so on an established
+        // connection a shutdown is the only thing that wakes it promptly.
         let _ = self.0.shutdown(Shutdown::Both);
     }
 }
 
 fn handle_connection(
     stream: TcpStream,
-    peer_addr: SocketAddr,
     registered: Registered,
     queued: Receiver<Vec<u8>>,
 ) -> Result<()> {
     let write_half = ShutdownOnDrop(stream.try_clone()?);
     write_half.0.set_write_timeout(Some(WRITE_TIMEOUT))?;
+    stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
 
-    let (host_address, peers) = {
+    let (host_address, peers, nonce) = {
         let node = registered.node.lock().expect("node lock poisoned");
-        (node.config.host_address, node.peers.len())
+        (node.config.host_address, node.peers.len(), node.nonce)
     };
     registered.record(format!(
-        "{host_address} is handling a connection from {peer_addr} ({peers} peers)"
+        "{host_address} is handling a connection from {} ({peers} peers)",
+        registered.address
     ));
 
-    let writer = thread::spawn(move || write_loop(&write_half.0, queued, PING_INTERVAL));
+    let ours = Message::new(Version::new(nonce, host_address))?.get_raw_format()?;
+    let writer = thread::spawn(move || write_loop(&write_half.0, queued, PING_INTERVAL, ours));
 
-    let read_result = read_loop(stream, peer_addr, &registered);
+    let read_result = read_loop(stream, &registered, HANDSHAKE_TIMEOUT);
 
     // Before the join, not after: the table holds this peer's only sender, and
     // while it does the writer never sees the disconnect that ends it.
@@ -166,7 +199,13 @@ fn write_loop<W: Write>(
     mut writer: W,
     queued: Receiver<Vec<u8>>,
     ping_interval: Duration,
+    opening: Vec<u8>,
 ) -> Result<()> {
+    // Ahead of the queue rather than in it: the peer's verack answers our
+    // version, so anything we enqueue before it would be talking to a peer that
+    // does not yet know who it is talking to.
+    writer.write_all(&opening)?;
+
     let mut next_ping = Instant::now();
 
     loop {
@@ -183,21 +222,48 @@ fn write_loop<W: Write>(
     }
 }
 
-fn read_loop<R: Read>(mut reader: R, peer_addr: SocketAddr, registered: &Registered) -> Result<()> {
+fn read_loop<R: Read>(
+    mut reader: R,
+    registered: &Registered,
+    handshake_timeout: Duration,
+) -> Result<()> {
     let mut buffer = [0u8; 4096];
     let mut recv_buffer: Vec<u8> = Vec::new();
+    let handshake_by = Instant::now() + handshake_timeout;
+    let mut ready = false;
 
     loop {
         match reader.read(&mut buffer) {
             Ok(0) => {
-                registered.record(format!("Connection with {peer_addr} closed"));
+                registered.record(format!("Connection with {} closed", registered.address));
                 return Ok(());
             }
             Ok(n) => process_incoming_bytes(registered, &mut recv_buffer, &buffer[..n])?,
             Err(e) if e.kind() == ErrorKind::Interrupted => {}
+            Err(e) if expired(&e) => {}
             Err(e) => return Err(e.into()),
         }
+
+        // Every turn, not only on an expiry: a peer that dribbles bytes it never
+        // finishes a handshake with keeps the read returning, and would sit here
+        // forever if only a silent one were checked. The latch is so an
+        // established peer stops locking the node once per read.
+        if !ready {
+            ready = registered.is_ready();
+
+            if !ready && Instant::now() >= handshake_by {
+                return Err(anyhow!(
+                    "no handshake from {} within {handshake_timeout:?}",
+                    registered.address
+                ));
+            }
+        }
     }
+}
+
+fn expired(e: &std::io::Error) -> bool {
+    // A read timeout is WouldBlock on Unix and TimedOut on Windows.
+    matches!(e.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut)
 }
 
 fn process_incoming_bytes(
@@ -216,6 +282,19 @@ fn process_incoming_bytes(
 
 fn handle_messages(registered: &Registered, message: MessageReceived) -> Result<()> {
     match message {
+        VersionMessage(version) => {
+            let peer = version.payload;
+            registered.advance_handshake(HandshakeEvent::Version)?;
+            registered.record(format!(
+                "{} speaks protocol {} and listens on {}",
+                registered.address, peer.protocol_version, peer.listen_address
+            ));
+            registered.deliver(Message::new(Verack)?.get_raw_format()?)?;
+        }
+        VerackMessage => {
+            registered.advance_handshake(HandshakeEvent::Verack)?;
+            registered.record(format!("Handshake with {} complete", registered.address));
+        }
         PingMessage(ping) => {
             registered.record(format!("Ping received {ping:?}"));
             let pong = Pong::new(ping.payload)?;
@@ -244,6 +323,19 @@ mod tests {
         (framed(ping), nonce)
     }
 
+    fn framed_version() -> Vec<u8> {
+        framed(Version::new(7, "127.0.0.1:5000".parse().unwrap()))
+    }
+
+    /// What a peer sends to be counted: its version, then a verack for ours.
+    fn identify(registered: &Registered) {
+        let mut recv_buffer = Vec::new();
+        let both = [framed_version(), framed(Verack)].concat();
+
+        process_incoming_bytes(registered, &mut recv_buffer, &both)
+            .expect("a well-formed handshake should be accepted");
+    }
+
     fn parse_all(bytes: &[u8]) -> Vec<MessageReceived> {
         let mut rest = bytes;
         let mut messages = Vec::new();
@@ -258,16 +350,19 @@ mod tests {
     }
 
     #[test]
-    fn the_first_ping_is_written_without_waiting_for_the_interval() {
+    fn the_opening_message_precedes_the_first_ping_which_does_not_wait_for_the_interval() {
         let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
         drop(outbound);
 
         let mut output = Vec::new();
-        write_loop(&mut output, queued, NEVER).unwrap();
+        write_loop(&mut output, queued, NEVER, framed_version()).unwrap();
 
         assert!(
-            matches!(parse_all(&output).as_slice(), [PingMessage(_)]),
-            "a new connection should ping at once, not after an hour"
+            matches!(
+                parse_all(&output).as_slice(),
+                [VersionMessage(_), PingMessage(_)]
+            ),
+            "a new connection identifies itself first, then pings at once rather than after an hour"
         );
     }
 
@@ -286,7 +381,7 @@ mod tests {
         });
 
         let mut output = Vec::new();
-        write_loop(&mut output, queued, NEVER).unwrap();
+        write_loop(&mut output, queued, NEVER, Vec::new()).unwrap();
         sender.join().unwrap();
 
         match parse_all(&output).as_slice() {
@@ -325,7 +420,7 @@ mod tests {
         // Dropping the peer cannot end this connection on its own: mpsc hands
         // the writer every buffered message before it ever reports
         // Disconnected, so the writer must give up on the socket itself.
-        write_loop(AcceptsThenStalls::default(), queued, NEVER)
+        write_loop(AcceptsThenStalls::default(), queued, NEVER, Vec::new())
             .expect_err("a write that cannot proceed must end the connection");
     }
 
@@ -355,7 +450,7 @@ mod tests {
         });
 
         let mut output = Vec::new();
-        write_loop(&mut output, queued, interval).unwrap();
+        write_loop(&mut output, queued, interval, Vec::new()).unwrap();
         holder.join().unwrap();
 
         let pings = parse_all(&output).len();
@@ -433,7 +528,7 @@ mod tests {
             interrupted: false,
         };
 
-        read_loop(reader, "127.0.0.1:1".parse().unwrap(), &registered)
+        read_loop(reader, &registered, NEVER)
             .expect("a signal-interrupted read must be retried, not fail the connection");
 
         let reply = queued.try_recv().expect("the ping after the interrupt");
@@ -457,6 +552,16 @@ mod tests {
             let read = stream.read(&mut chunk).expect("peer went quiet");
             assert_ne!(0, read, "peer closed before sending the expected message");
             buffer.extend_from_slice(&chunk[..read]);
+        }
+    }
+
+    /// The next message that is a reply to something, rather than the timer's.
+    fn next_reply(stream: &mut TcpStream, buffer: &mut Vec<u8>) -> MessageReceived {
+        loop {
+            match next_message(stream, buffer) {
+                PingMessage(_) => continue,
+                reply => return reply,
+            }
         }
     }
 
@@ -491,7 +596,7 @@ mod tests {
         let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
         let registered = Registered::open(&node, peer_addr, Origin::Accepted, outbound)
             .expect("an empty table should accept a peer");
-        handle_connection(stream, peer_addr, registered, queued)
+        handle_connection(stream, registered, queued)
     }
 
     /// A peer in a node's table, plus the queue its writer would drain.
@@ -524,8 +629,12 @@ mod tests {
 
         let mut buffer = Vec::new();
         assert!(
+            matches!(next_message(&mut peer, &mut buffer), VersionMessage(_)),
+            "a connection should open by identifying itself"
+        );
+        assert!(
             matches!(next_message(&mut peer, &mut buffer), PingMessage(_)),
-            "a connection should open by pinging its peer"
+            "and then ping its peer"
         );
 
         let (ping, nonce) = framed_ping();
@@ -535,6 +644,202 @@ mod tests {
             PongMessage(pong) => assert_eq!(nonce, pong.payload.nonce),
             other => panic!("expected a pong for our ping, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn the_version_a_connection_opens_with_carries_the_nodes_nonce_and_listen_address() {
+        let (mut peer, accepted, peer_addr) = a_connected_pair();
+        let node = a_node();
+        let (nonce, listening_on) = {
+            let node = node.lock().unwrap();
+            (node.nonce, node.config.host_address)
+        };
+
+        thread::spawn(move || handle_alone(accepted, peer_addr, node));
+
+        match next_message(&mut peer, &mut Vec::new()) {
+            VersionMessage(version) => {
+                assert_eq!(nonce, version.payload.nonce);
+                assert_eq!(
+                    listening_on, version.payload.listen_address,
+                    "a peer re-dials the address we advertise, not the one it sees"
+                );
+            }
+            other => panic!("expected a version, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_peer_that_exchanges_version_and_verack_over_a_socket_reaches_ready() {
+        let (mut peer, accepted, _) = a_connected_pair();
+        let node = a_node();
+        let watched = Arc::clone(&node);
+
+        spawn_connection(accepted, node, Origin::Accepted);
+
+        let mut buffer = Vec::new();
+        assert!(matches!(
+            next_message(&mut peer, &mut buffer),
+            VersionMessage(_)
+        ));
+
+        peer.write_all(&framed_version()).unwrap();
+        // Past the keep-alive ping: gating that on Ready is #42's job, not this
+        // ticket's, so it may legitimately arrive before the verack.
+        assert!(
+            matches!(next_reply(&mut peer, &mut buffer), VerackMessage),
+            "a version must be answered with a verack"
+        );
+
+        peer.write_all(&framed(Verack)).unwrap();
+        eventually(
+            || {
+                let node = watched.lock().unwrap();
+                node.peers
+                    .ids()
+                    .first()
+                    .and_then(|id| node.peers.handshake_of(*id))
+                    .is_some_and(Handshake::is_ready)
+            },
+            "the peer never reached Ready after a completed handshake",
+        );
+    }
+
+    #[test]
+    fn a_version_is_answered_with_a_verack_and_only_their_verack_completes_it() {
+        let (registered, queued) = a_registered_peer();
+        let mut recv_buffer = Vec::new();
+
+        process_incoming_bytes(&registered, &mut recv_buffer, &framed_version()).unwrap();
+
+        assert!(
+            !registered.is_ready(),
+            "their version is half a handshake; ours is still unanswered"
+        );
+        let reply = queued.try_recv().expect("a version must be answered");
+        assert!(
+            matches!(parse_all(&reply).as_slice(), [VerackMessage]),
+            "expected a verack, got {:?}",
+            parse_all(&reply)
+        );
+
+        process_incoming_bytes(&registered, &mut recv_buffer, &framed(Verack)).unwrap();
+
+        assert!(registered.is_ready());
+        assert!(queued.try_recv().is_err(), "a verack is not itself answered");
+    }
+
+    #[test]
+    fn a_verack_before_any_version_is_refused() {
+        let (registered, queued) = a_registered_peer();
+
+        process_incoming_bytes(&registered, &mut Vec::new(), &framed(Verack))
+            .expect_err("a verack answers a version this peer never sent");
+
+        assert!(!registered.is_ready());
+        assert!(queued.try_recv().is_err(), "nothing is owed to a bad peer");
+    }
+
+    #[test]
+    fn a_second_version_after_the_handshake_is_a_protocol_error() {
+        let (registered, queued) = a_registered_peer();
+        identify(&registered);
+        while queued.try_recv().is_ok() {}
+
+        process_incoming_bytes(&registered, &mut Vec::new(), &framed_version())
+            .expect_err("a handshake happens once; a second version is not a second one");
+
+        assert!(
+            queued.try_recv().is_err(),
+            "a refused version must not be answered with another verack"
+        );
+    }
+
+    #[test]
+    fn a_peer_that_never_identifies_itself_loses_its_connection() {
+        /// Connected and silent: every read expires the way a socket's read
+        /// timeout does. It gives up eventually, so a node that stopped
+        /// enforcing the deadline fails this test instead of hanging the suite.
+        struct SaysNothing(usize);
+
+        impl Read for SaysNothing {
+            fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+                if self.0 == 0 {
+                    return Ok(0);
+                }
+                self.0 -= 1;
+                thread::sleep(Duration::from_millis(5));
+                Err(std::io::Error::from(ErrorKind::WouldBlock))
+            }
+        }
+
+        let (registered, _queued) = a_registered_peer();
+
+        let error = read_loop(SaysNothing(40), &registered, Duration::from_millis(50))
+            .expect_err("a peer that never identifies itself must not hold a slot forever");
+
+        assert!(format!("{error:#}").contains("no handshake"), "got: {error:#}");
+    }
+
+    #[test]
+    fn a_peer_that_talks_without_identifying_itself_still_loses_its_connection() {
+        /// Legal traffic, no handshake. Every read returns bytes, so the read
+        /// timeout never expires and only an absolute deadline ends this. It
+        /// runs out, so a node that lost the deadline fails rather than hangs.
+        struct Chatters {
+            pong: Vec<u8>,
+            left: usize,
+        }
+
+        impl Read for Chatters {
+            fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+                if self.left == 0 {
+                    return Ok(0);
+                }
+                self.left -= 1;
+                thread::sleep(Duration::from_millis(2));
+                buffer[..self.pong.len()].copy_from_slice(&self.pong);
+                Ok(self.pong.len())
+            }
+        }
+
+        let (registered, _queued) = a_registered_peer();
+        let chatty = Chatters {
+            pong: framed(Pong::new(Ping::new()).unwrap()),
+            left: 100,
+        };
+
+        let error = read_loop(chatty, &registered, Duration::from_millis(50))
+            .expect_err("the handshake deadline is absolute, not reset by every read");
+
+        assert!(format!("{error:#}").contains("no handshake"), "got: {error:#}");
+    }
+
+    #[test]
+    fn a_peer_that_did_identify_itself_survives_a_read_that_expires() {
+        struct ExpiresThenCloses {
+            expired: bool,
+        }
+
+        impl Read for ExpiresThenCloses {
+            fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+                if !self.expired {
+                    self.expired = true;
+                    return Err(std::io::Error::from(ErrorKind::WouldBlock));
+                }
+                Ok(0)
+            }
+        }
+
+        let (registered, _queued) = a_registered_peer();
+        identify(&registered);
+
+        read_loop(
+            ExpiresThenCloses { expired: false },
+            &registered,
+            Duration::from_millis(1),
+        )
+        .expect("a quiet established peer is not a peer that failed to hand shake");
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -25,8 +25,8 @@ const PING_INTERVAL: Duration = Duration::from_secs(11);
 const WRITE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// How long a connection may go without identifying itself. It doubles as the
-/// read half's timeout, so a peer that connects and then says nothing wakes the
-/// reader at all rather than parking it against a deadline it cannot see.
+/// read half's timeout, so a silent peer wakes the reader rather than parking it
+/// against a deadline it cannot see.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
 
 pub fn connect(addr: SocketAddr, node: SharedNode) -> Result<()> {
@@ -74,7 +74,7 @@ fn spawn_connection(stream: TcpStream, node: SharedNode, origin: Origin) {
             }
         };
 
-        if let Err(e) = handle_connection(stream, registered, queued) {
+        if let Err(e) = handle_connection(stream, registered, queued, HANDSHAKE_TIMEOUT) {
             record(&node, format!("Connection with {peer} ended: {e:#}"));
         }
     });
@@ -166,10 +166,11 @@ fn handle_connection(
     stream: TcpStream,
     registered: Registered,
     queued: Receiver<Vec<u8>>,
+    handshake_timeout: Duration,
 ) -> Result<()> {
     let write_half = ShutdownOnDrop(stream.try_clone()?);
     write_half.0.set_write_timeout(Some(WRITE_TIMEOUT))?;
-    stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
+    stream.set_read_timeout(Some(handshake_timeout))?;
 
     let (host_address, peers, nonce) = {
         let node = registered.node.lock().expect("node lock poisoned");
@@ -183,7 +184,7 @@ fn handle_connection(
     let ours = Message::new(Version::new(nonce, host_address))?.get_raw_format()?;
     let writer = thread::spawn(move || write_loop(&write_half.0, queued, PING_INTERVAL, ours));
 
-    let read_result = read_loop(stream, &registered, HANDSHAKE_TIMEOUT);
+    let read_result = read_loop(stream, &registered, handshake_timeout);
 
     // Before the join, not after: the table holds this peer's only sender, and
     // while it does the writer never sees the disconnect that ends it.
@@ -201,9 +202,7 @@ fn write_loop<W: Write>(
     ping_interval: Duration,
     opening: Vec<u8>,
 ) -> Result<()> {
-    // Ahead of the queue rather than in it: the peer's verack answers our
-    // version, so anything we enqueue before it would be talking to a peer that
-    // does not yet know who it is talking to.
+    // Ahead of the queue, not in it, so nothing we enqueue can precede it.
     writer.write_all(&opening)?;
 
     let mut next_ping = Instant::now();
@@ -244,10 +243,8 @@ fn read_loop<R: Read>(
             Err(e) => return Err(e.into()),
         }
 
-        // Every turn, not only on an expiry: a peer that dribbles bytes it never
-        // finishes a handshake with keeps the read returning, and would sit here
-        // forever if only a silent one were checked. The latch is so an
-        // established peer stops locking the node once per read.
+        // Absolute, not per-read: a peer dribbling legal traffic would reset a
+        // per-read deadline forever. The latch keeps a settled peer off the lock.
         if !ready {
             ready = registered.is_ready();
 
@@ -439,6 +436,42 @@ mod tests {
     }
 
     #[test]
+    fn a_connection_bounds_how_long_it_waits_to_be_told_who_it_is_talking_to() {
+        let (_peer, accepted, peer_addr) = a_connected_pair();
+        let observer = accepted.try_clone().unwrap();
+
+        thread::spawn(move || handle_alone(accepted, peer_addr, a_node()));
+
+        eventually(
+            || observer.read_timeout().unwrap().is_some(),
+            "the read half never had its waiting bounded",
+        );
+        assert_eq!(Some(HANDSHAKE_TIMEOUT), observer.read_timeout().unwrap());
+    }
+
+    #[test]
+    fn a_peer_that_never_identifies_itself_gives_its_slot_back() {
+        let (_peer, accepted, peer_addr) = a_connected_pair();
+        let node = a_node();
+        let watched = Arc::clone(&node);
+
+        thread::spawn(move || {
+            handle_alone_for(accepted, peer_addr, node, Duration::from_millis(50))
+        });
+
+        eventually(
+            || watched.lock().unwrap().peers.len() == 1,
+            "the connection never registered a peer",
+        );
+        // The slot and its 32 MiB recv_buffer are what the deadline is for;
+        // ending the connection without freeing them would miss the point.
+        eventually(
+            || watched.lock().unwrap().peers.is_empty(),
+            "a peer that never identified itself kept its slot",
+        );
+    }
+
+    #[test]
     fn pings_recur_at_the_configured_interval() {
         let interval = Duration::from_millis(20);
         let run_for = Duration::from_millis(300);
@@ -593,10 +626,19 @@ mod tests {
     /// What spawn_connection does, minus the registry, for tests about the
     /// thread pair rather than about the peer table.
     fn handle_alone(stream: TcpStream, peer_addr: SocketAddr, node: SharedNode) -> Result<()> {
+        handle_alone_for(stream, peer_addr, node, HANDSHAKE_TIMEOUT)
+    }
+
+    fn handle_alone_for(
+        stream: TcpStream,
+        peer_addr: SocketAddr,
+        node: SharedNode,
+        handshake_timeout: Duration,
+    ) -> Result<()> {
         let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
         let registered = Registered::open(&node, peer_addr, Origin::Accepted, outbound)
             .expect("an empty table should accept a peer");
-        handle_connection(stream, registered, queued)
+        handle_connection(stream, registered, queued, handshake_timeout)
     }
 
     /// A peer in a node's table, plus the queue its writer would drain.
@@ -965,7 +1007,7 @@ mod tests {
     }
 
     #[test]
-    fn losing_the_write_half_wakes_a_reader_that_has_no_timeout() {
+    fn losing_the_write_half_wakes_a_parked_reader() {
         let (peer, accepted, _) = a_connected_pair();
         let write_half = ShutdownOnDrop(accepted.try_clone().unwrap());
         let mut read_half = accepted;
@@ -988,6 +1030,8 @@ mod tests {
         finished
             .recv_timeout(Duration::from_secs(5))
             .expect("dropping the write half must wake a reader parked in read()");
+        // Not left to the read timeout: on an established connection that is
+        // 20s away, and teardown cannot wait on it.
         drop(peer);
     }
 }

--- a/test/functional/framework/messages.py
+++ b/test/functional/framework/messages.py
@@ -6,6 +6,7 @@ decode, and the wire format is the one contract this project promises. If this
 file and `src/messages/` ever disagree, that is the suite working.
 """
 
+import ipaddress
 import struct
 from dataclasses import dataclass
 from hashlib import sha256
@@ -15,6 +16,12 @@ MAGIC = bytes([0xF9, 0xBE, 0xB4, 0xD9])
 HEADER_LENGTH = 24
 COMMAND_LENGTH = 12
 MAX_PAYLOAD_SIZE = 32 * 1024 * 1024
+PROTOCOL_VERSION = 1
+
+# What each command's payload must weigh. A node that sends a different number
+# of bytes under one of these names has broken the format, so this is an
+# assertion about the node rather than a lookup table.
+PAYLOAD_SIZES = {"ping": 8, "pong": 8, "version": 30, "verack": 0}
 
 
 def hash256(payload: bytes) -> bytes:
@@ -45,10 +52,64 @@ def pong(nonce: int) -> bytes:
     return frame("pong", struct.pack("<Q", nonce))
 
 
+def version(
+    nonce: int, listen_address: str, protocol_version: int = PROTOCOL_VERSION
+) -> bytes:
+    return frame(
+        "version",
+        struct.pack("<IQ", protocol_version, nonce) + pack_address(listen_address),
+    )
+
+
+def verack() -> bytes:
+    return frame("verack", b"")
+
+
+def pack_address(address: str) -> bytes:
+    """16 bytes of IPv6 and a port, with IPv4 mapped in, so one field fits both."""
+    host, port = address.rsplit(":", 1)
+    parsed = ipaddress.ip_address(host.strip("[]"))
+    mapped = (
+        ipaddress.IPv6Address(f"::ffff:{parsed}") if parsed.version == 4 else parsed
+    )
+
+    return mapped.packed + struct.pack("<H", int(port))
+
+
+def unpack_address(packed: bytes) -> str:
+    mapped = ipaddress.IPv6Address(packed[:16])
+    (port,) = struct.unpack("<H", packed[16:18])
+    host = mapped.ipv4_mapped
+
+    return f"{host}:{port}" if host is not None else f"[{mapped}]:{port}"
+
+
+@dataclass(frozen=True)
+class Version:
+    protocol_version: int
+    nonce: int
+    listen_address: str
+
+
 @dataclass(frozen=True)
 class Frame:
     command: str
-    nonce: int
+    payload: bytes
+
+    @property
+    def nonce(self) -> int:
+        assert len(self.payload) == 8, f"a {self.command} carries no bare nonce"
+        return struct.unpack("<Q", self.payload)[0]
+
+    def as_version(self) -> Version:
+        assert self.command == "version", f"a {self.command} is not a version"
+        protocol_version, nonce = struct.unpack("<IQ", self.payload[:12])
+
+        return Version(
+            protocol_version=protocol_version,
+            nonce=nonce,
+            listen_address=unpack_address(self.payload[12:]),
+        )
 
 
 def parse(buffer: bytes) -> Tuple[Optional[Frame], int]:
@@ -75,12 +136,13 @@ def parse(buffer: bytes) -> Tuple[Optional[Frame], int]:
     ), "checksum does not cover the payload it was sent with"
 
     command = buffer[4 : 4 + COMMAND_LENGTH].rstrip(b"\0").decode("ascii")
-    assert (
-        len(payload) == 8
-    ), f"{command} should carry an 8-byte nonce, got {len(payload)}"
+    assert command in PAYLOAD_SIZES, f"node emitted an unknown command {command!r}"
+    assert len(payload) == PAYLOAD_SIZES[command], (
+        f"a {command} should carry {PAYLOAD_SIZES[command]} bytes, "
+        f"got {len(payload)}"
+    )
 
-    (nonce,) = struct.unpack("<Q", payload)
-    return Frame(command=command, nonce=nonce), HEADER_LENGTH + size
+    return Frame(command=command, payload=payload), HEADER_LENGTH + size
 
 
 def parse_all(buffer: bytes) -> list:

--- a/test/functional/framework/p2p.py
+++ b/test/functional/framework/p2p.py
@@ -71,10 +71,10 @@ class Peer:
 
         raise AssertionError(f"the node sent no {command} within {PATIENCE}s")
 
-    def handshake(self, listen_address: str = "127.0.0.1:5000", nonce: int = 0x51DE) -> None:
+    def handshake(self) -> None:
         """Become a peer: answer the node's version, and send our own."""
         self.next_frame_of("version")
-        self.send(version(nonce, listen_address))
+        self.send(version(0x51DE, "127.0.0.1:5000"))
         self.next_frame_of("verack")
         self.send(verack())
 

--- a/test/functional/framework/p2p.py
+++ b/test/functional/framework/p2p.py
@@ -8,7 +8,7 @@ import socket
 import time
 from typing import List, Optional
 
-from .messages import Frame, parse
+from .messages import Frame, parse, verack, version
 
 # How long to wait for something that should happen. Every operation it guards
 # -- a process exec, a loopback connect, a ping already queued -- is sub-second
@@ -55,6 +55,28 @@ class Peer:
                 ) from None
             assert received, "the node closed the connection unexpectedly"
             self.buffer += received
+
+    def next_frame_of(self, command: str) -> Frame:
+        """The next frame of one kind, past whatever else the node is saying.
+
+        A deadline around the loop, not just inside `next_frame`: a node that
+        keeps sending something else would otherwise reset the clock forever.
+        """
+        deadline = time.monotonic() + PATIENCE
+
+        while time.monotonic() < deadline:
+            received = self.next_frame()
+            if received.command == command:
+                return received
+
+        raise AssertionError(f"the node sent no {command} within {PATIENCE}s")
+
+    def handshake(self, listen_address: str = "127.0.0.1:5000", nonce: int = 0x51DE) -> None:
+        """Become a peer: answer the node's version, and send our own."""
+        self.next_frame_of("version")
+        self.send(version(nonce, listen_address))
+        self.next_frame_of("verack")
+        self.send(verack())
 
     def frames_within(self, window: float = IMPATIENCE) -> List[Frame]:
         """Everything the node says within `window`.

--- a/test/functional/test_configuration.py
+++ b/test/functional/test_configuration.py
@@ -21,7 +21,7 @@ def test_a_config_file_supplies_the_listening_address(net):
     )
 
     peer = net.track(expect_dialled(probe))
-    assert peer.next_frame().command == "ping"
+    assert peer.next_frame().command == "version"
 
 
 def test_a_command_line_address_overrides_the_config_file(net):
@@ -38,7 +38,7 @@ def test_a_command_line_address_overrides_the_config_file(net):
     )
 
     peer = net.track(expect_dialled(chosen))
-    assert peer.next_frame().command == "ping"
+    assert peer.next_frame().command == "version"
 
     assert (
         accept_within(ignored, IMPATIENCE) is None

--- a/test/functional/test_connections.py
+++ b/test/functional/test_connections.py
@@ -5,7 +5,7 @@ from framework.p2p import address_of, expect_dialled
 def test_a_node_pings_whoever_dials_it(net):
     node = net.node("--host-address", "127.0.0.1:0")
 
-    assert net.dial(node.listening_on()).next_frame().command == "ping"
+    assert net.dial(node.listening_on()).next_frame_of("ping").command == "ping"
 
 
 def test_a_node_answers_a_ping_with_a_pong_carrying_the_same_nonce(net):
@@ -32,22 +32,21 @@ def test_a_node_dials_every_address_it_was_given(net):
 
     for listening in (first, second):
         peer = net.track(expect_dialled(listening))
-        assert peer.next_frame().command == "ping"
+        assert peer.next_frame().command == "version"
 
 
 def test_a_pong_is_accepted_and_does_not_provoke_another_pong(net):
     node = net.node("--host-address", "127.0.0.1:0")
     peer = net.dial(node.listening_on())
 
-    opening = peer.next_frame()
-    assert opening.command == "ping"
+    opening = peer.next_frame_of("ping")
     peer.send(pong(opening.nonce))
 
     node.line_containing("Pong received")
     peer.expect_silence()
 
 
-def test_two_real_nodes_complete_a_ping_pong_round_trip(net):
+def test_two_real_nodes_hand_shake_and_complete_a_ping_pong_round_trip(net):
     listener = net.node("--host-address", "127.0.0.1:0")
 
     dialler = net.node(
@@ -58,7 +57,9 @@ def test_two_real_nodes_complete_a_ping_pong_round_trip(net):
     )
 
     # A pong only arrives if the other node parsed our ping, framed a reply,
-    # and we parsed that -- the whole path, in both directions. This is the one
-    # assertion on stdout, and it goes away when M6 provides an API.
-    listener.line_containing("Pong received")
-    dialler.line_containing("Pong received")
+    # and we parsed that -- the whole path, in both directions, and only after
+    # each accepted the other as a peer. This is the one test that reads stdout,
+    # and it goes away when M6 provides an API.
+    for node in (listener, dialler):
+        node.line_containing("Handshake with")
+        node.line_containing("Pong received")

--- a/test/functional/test_handshake.py
+++ b/test/functional/test_handshake.py
@@ -1,0 +1,87 @@
+"""A connection is not a peer until both sides have said who they are."""
+
+from framework.messages import PROTOCOL_VERSION, frame, ping, verack, version
+
+
+def test_a_node_opens_a_connection_by_identifying_itself(net):
+    node = net.node("--host-address", "127.0.0.1:0")
+    address = node.listening_on()
+
+    said = net.dial(address).next_frame().as_version()
+
+    assert said.protocol_version == PROTOCOL_VERSION
+    assert said.listen_address == address, (
+        "a peer re-dials the address we advertise, so it must be the bound one "
+        "and not the 127.0.0.1:0 that was asked for"
+    )
+
+
+def test_each_node_mints_its_own_nonce(net):
+    """#41 tells a self-connection apart by this, and cannot if they collide."""
+    first = net.node("--host-address", "127.0.0.1:0")
+    second = net.node("--host-address", "127.0.0.1:0")
+
+    nonces = {
+        net.dial(node.listening_on()).next_frame().as_version().nonce
+        for node in (first, second)
+    }
+
+    assert len(nonces) == 2, f"two nodes advertised the same nonce: {nonces}"
+
+
+def test_a_version_is_answered_with_a_verack(net):
+    node = net.node("--host-address", "127.0.0.1:0")
+    peer = net.dial(node.listening_on())
+    peer.next_frame_of("version")
+
+    peer.send(version(0x1122334455667788, "127.0.0.1:5000"))
+
+    assert peer.next_frame_of("verack").payload == b""
+
+
+def test_a_peer_that_completes_the_handshake_keeps_talking(net):
+    node = net.node("--host-address", "127.0.0.1:0")
+    peer = net.dial(node.listening_on())
+
+    peer.handshake()
+    peer.send(ping(0xFEEDFACE))
+
+    assert peer.pongs_within() == [0xFEEDFACE]
+
+
+def test_a_peer_sending_a_verack_it_was_never_owed_is_dropped(net):
+    node = net.node("--host-address", "127.0.0.1:0")
+    address = node.listening_on()
+
+    villain = net.dial(address)
+    villain.next_frame_of("version")
+    villain.send(verack())
+    villain.expect_closed()
+
+    assert net.dial(address).next_frame().command == "version"
+
+
+def test_a_second_version_after_the_handshake_is_refused(net):
+    node = net.node("--host-address", "127.0.0.1:0")
+    address = node.listening_on()
+
+    villain = net.dial(address)
+    villain.handshake()
+    villain.send(version(0x1122334455667788, "127.0.0.1:5000"))
+    villain.expect_closed()
+
+    assert net.dial(address).next_frame().command == "version"
+
+
+def test_a_verack_carrying_a_payload_is_not_a_verack(net):
+    node = net.node("--host-address", "127.0.0.1:0")
+    address = node.listening_on()
+
+    villain = net.dial(address)
+    villain.next_frame_of("version")
+    villain.send(version(0x1122334455667788, "127.0.0.1:5000"))
+    # Correctly framed and checksummed, so it is refused for its body alone.
+    villain.send(frame("verack", b"\0"))
+    villain.expect_closed()
+
+    assert net.dial(address).next_frame().command == "version"

--- a/test/functional/test_hostile_peers.py
+++ b/test/functional/test_hostile_peers.py
@@ -19,7 +19,7 @@ def test_a_peer_speaking_another_networks_magic_bytes_is_dropped(net):
     villain.send(bytes(foreign))
     villain.expect_closed()
 
-    assert net.dial(address).next_frame().command == "ping"
+    assert net.dial(address).next_frame().command == "version"
 
 
 def test_a_peer_claiming_a_four_gigabyte_payload_is_dropped(net):
@@ -32,7 +32,7 @@ def test_a_peer_claiming_a_four_gigabyte_payload_is_dropped(net):
     villain.send(bytes(header))
     villain.expect_closed()
 
-    assert net.dial(address).next_frame().command == "ping"
+    assert net.dial(address).next_frame().command == "version"
 
 
 def test_a_payload_at_the_limit_is_not_refused_for_being_too_large(net):
@@ -45,7 +45,7 @@ def test_a_payload_at_the_limit_is_not_refused_for_being_too_large(net):
     peer = net.dial(node.listening_on())
     peer.send(bytes(header))
 
-    assert peer.next_frame().command == "ping", "the connection should still be live"
+    assert peer.next_frame().command == "version", "the connection should still be live"
 
 
 def test_a_peer_whose_payload_does_not_match_its_checksum_is_dropped(net):
@@ -58,7 +58,7 @@ def test_a_peer_whose_payload_does_not_match_its_checksum_is_dropped(net):
     villain.send(bytes(corrupted))
     villain.expect_closed()
 
-    assert net.dial(address).next_frame().command == "ping"
+    assert net.dial(address).next_frame().command == "version"
 
 
 def test_a_peer_sending_an_unknown_command_is_dropped(net):
@@ -69,7 +69,7 @@ def test_a_peer_sending_an_unknown_command_is_dropped(net):
     villain.send(frame("notacommand", struct.pack("<Q", 7)))
     villain.expect_closed()
 
-    assert net.dial(address).next_frame().command == "ping"
+    assert net.dial(address).next_frame().command == "version"
 
 
 def test_a_peer_that_vanishes_mid_message_does_not_take_the_node_down(net):
@@ -80,4 +80,4 @@ def test_a_peer_that_vanishes_mid_message_does_not_take_the_node_down(net):
     deserter.send(ping(1)[: HEADER_LENGTH - 4])
     deserter.close()
 
-    assert net.dial(address).next_frame().command == "ping"
+    assert net.dial(address).next_frame().command == "version"

--- a/test/functional/test_startup.py
+++ b/test/functional/test_startup.py
@@ -58,4 +58,4 @@ def test_an_unreachable_peer_is_logged_and_the_node_keeps_listening(net):
     address = node.listening_on()
 
     node.line_containing("Could not connect")
-    assert net.dial(address).next_frame().command == "ping"
+    assert net.dial(address).next_frame().command == "version"


### PR DESCRIPTION
Closes #40.

A connection now opens with `version` and only becomes a peer once the other side's `version` **and** `verack` have both arrived. The state lives on `PeerHandle` as `AwaitingVersion → AwaitingVerack → Ready`, advanced only by what the peer sends.

### The three decisions worth arguing with

**The writer's first write is our version, passed in rather than queued.** `write_loop` already owned every write and opened by pinging; putting the version on the outbound queue instead would have let the ping precede the message that says who is speaking. It is a parameter, so it is also the seam the tests use.

**The handshake deadline is absolute, checked on every turn of the read loop** — not a per-read socket timeout. A per-read timeout catches a peer that goes silent and nothing else: one dribbling legal traffic it never completes a handshake with resets the clock forever and keeps a slot and a 32 MiB `recv_buffer`. `a_peer_that_talks_without_identifying_itself_still_loses_its_connection` is that case.

**`main` writes the bound address back over `config.host_address`.** `:0` asks the OS to choose a port, and the chosen one is what a peer must be told to dial back on — a node advertising `127.0.0.1:0` is un-redialable, which is the whole point of the field. This is the one value written after resolution; CLAUDE.md's config section and ARCHITECTURE's `config.rs` row both say so now.

### Deliberately not here

Relay is **not** gated on Ready — the keep-alive ping and the pong answering one still go out mid-handshake. That is #42, and its absence is stated in ARCHITECTURE, the glossary, and the one test that would otherwise look wrong.

The nonce is carried and advertised but not yet *acted* on; recognising ourselves in it is #41.

### Mutation results

Coverage is proven by reverting each guarantee and checking what goes red, per ADR-0014.

| Mutation | Caught by |
|---|---|
| Handshake deadline never fires | 3 Rust tests |
| Any handshake transition is legal | 6 Rust tests |
| A version is not answered with a verack | 2 Rust tests |
| The connection does not open with its version | 4 Rust tests |
| The read half is never bounded | 2 Rust tests |
| A verack may carry a body | 1 Rust + 1 functional |
| A version may carry trailing bytes | 1 Rust test |
| **Port big-endian on _both_ sides** | **functional only** — all 163 Rust tests still passed |
| **`version` advertises the configured address, not the bound one** | **functional only** |

The last two are the reason `framework/messages.py` is a second implementation: a bug symmetric across encode and decode is invisible to a round-trip test, and only an independently-written decoder sees it.

### Review

`/code-review` was run on the branch. Both axes are folded into the second commit: the nonce helper moved out of the message module, `handle_connection` gained the timeout parameter so the constant-to-socket wiring and the slot-freeing are actually reached by tests, `version` became strict about its length, and the comments that had grown into a second copy of ARCHITECTURE's prose were cut back.

166 Rust tests, 29 functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)