### PR TITLE
Send nothing to a peer that has not said who it is

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,10 @@
 name: Tests
 
 on:
+  # Every pull request, not only those based on main: a stacked PR sits on
+  # another feature branch, and filtering by base silently gave it no checks
+  # at all rather than a red one.
   pull_request:
-    branches: [ main ]
   push:
     branches: [ main ]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,9 +94,13 @@ The node is a small P2P server modeled on Bitcoin's message framing. `main.rs` b
 
 Each connection then runs `handle_connection`, which splits into **two threads** over `try_clone()`d socket handles, joined by a *bounded* `sync_channel` of already-framed bytes:
 - the **reader** blocks in `read` under the handshake timeout, appends to a growing `recv_buffer`, drains complete messages out of it, and *enqueues* replies (Ping → Pong, Version → Verack) rather than writing them;
-- the **writer** owns every write. Its first is our `version`, passed in rather than queued so nothing can precede it. Then it drains the channel with `recv_timeout`, and that timeout *is* the ping timer — a `Ping` goes out every `PING_INTERVAL` (11s) whatever the reader is doing, first ping immediately. The interval is a parameter of `write_loop`, so tests use milliseconds.
+- the **writer** owns every write. Its first is our `version`, passed in rather than queued so nothing can precede it. Then it drains the channel with `recv_timeout`, and that timeout *is* the ping timer — a `Ping` goes out every `PING_INTERVAL` (11s) whatever the reader is doing, but **only to a Ready peer**. The interval is a parameter of `write_loop`, so tests use milliseconds.
 
-A peer is **Ready** only once its `version` and `verack` have both arrived; the state lives on `PeerHandle` and advances in one order, once. `HANDSHAKE_TIMEOUT` (20s) is an absolute deadline checked on every turn of the read loop — not a per-read timeout, which a peer sending legal traffic would reset forever. Nothing is gated on Ready yet: pings and pongs still flow mid-handshake.
+A peer is **Ready** only once its `version` and `verack` have both arrived; the state lives on `PeerHandle` and advances in one order, once. `HANDSHAKE_TIMEOUT` (20s) is an absolute deadline checked on every turn of the read loop — not a per-read timeout, which a peer sending legal traffic would reset forever.
+
+**Nothing is sent to a peer that is not Ready.** `send_to` returns `Delivered::NotReady` and queues nothing; `broadcast` skips it and does not count it; the writer holds its ping. The single exception is `PeerTable::answer_handshake`, which carries our `verack` — it necessarily precedes Ready, so gating it would be the handshake waiting on itself. `NotReady` is not a connection failure: a peer that pings us mid-handshake is simply not answered.
+
+Becoming Ready is also what *starts* the keep-alive: `handle_messages` enqueues the first ping on their `verack`, because the writer's timer would not fire for a whole interval and nothing else would wake it.
 
 **Identity is the `version` nonce, never an address** ([ADR-0015](docs/adr/0015-peer-identity-and-duplicate-connections.md)). `Node::identify` runs when a `version` arrives: our own nonce drops the connection, and a nonce already in the table leaves exactly one of the two standing — the one dialled by the larger nonce. `PeerTable` has no address dedup left.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,9 +98,7 @@ Each connection then runs `handle_connection`, which splits into **two threads**
 
 A peer is **Ready** only once its `version` and `verack` have both arrived; the state lives on `PeerHandle` and advances in one order, once. `HANDSHAKE_TIMEOUT` (20s) is an absolute deadline checked on every turn of the read loop — not a per-read timeout, which a peer sending legal traffic would reset forever.
 
-**Nothing is sent to a peer that is not Ready.** `send_to` returns `Delivered::NotReady` and queues nothing; `broadcast` skips it and does not count it; the writer holds its ping. The single exception is `PeerTable::answer_handshake`, which carries our `verack` — it necessarily precedes Ready, so gating it would be the handshake waiting on itself. `NotReady` is not a connection failure: a peer that pings us mid-handshake is simply not answered.
-
-Becoming Ready is also what *starts* the keep-alive: `handle_messages` enqueues the first ping on their `verack`, because the writer's timer would not fire for a whole interval and nothing else would wake it.
+**Nothing is sent to a peer that is not Ready** — `send_to` returns `Delivered::NotReady` and queues nothing, `broadcast` skips it, the writer holds its ping. The one way past is `PeerTable::answer_handshake`, open only to a peer in `AwaitingVerack`. Their `verack` is also what starts the keep-alive. Both are explained in [ARCHITECTURE](docs/ARCHITECTURE.md#the-handshake).
 
 **Identity is the `version` nonce, never an address** ([ADR-0015](docs/adr/0015-peer-identity-and-duplicate-connections.md)). `Node::identify` runs when a `version` arrives: our own nonce drops the connection, and a nonce already in the table leaves exactly one of the two standing — the one dialled by the larger nonce. `PeerTable` has no address dedup left.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,12 +76,7 @@ Delivery is `try_send`, never a blocking send: one stalled socket must not hold
 the node's lock and stop delivery to everyone else. A peer whose queue is full
 past `OUTBOUND_QUEUE` (128 messages) is **dropped**, not buffered.
 
-Delivery is also gated on **Ready**: `send_to` and `broadcast` queue nothing for
-a peer that has not identified itself, and the writer holds its ping. Only
-`answer_handshake` — our `verack` — goes out before Ready, because it is what
-makes the peer Ready. `send_to` reports `NotReady` rather than failing, since
-declining to answer an unidentified peer is the rule working, not a broken
-connection.
+Delivery is also gated on **Ready** — see [the handshake](#the-handshake).
 
 Dropping it is not on its own enough to end the connection, and the reason is
 worth knowing: `mpsc` hands the writer every *buffered* message before it ever
@@ -134,11 +129,24 @@ per-read timeout would never fire on it. Failing it ends the connection through
 the same path as any other read error, so the slot and the `recv_buffer` go with
 it.
 
-Until Ready, a connection has sent exactly one message — our `version` — and
-answered exactly one, with a `verack`. Nothing else, in either direction, is
-queued or written. Their `verack` is also what starts the keep-alive: the writer's
-timer would otherwise not fire for a full `PING_INTERVAL`, and nothing wakes it,
-so the reader enqueues the first ping as it advances the peer to Ready.
+**Nothing is sent to a peer that is not Ready.** `send_to` queues nothing and
+reports `Delivered::NotReady`; `broadcast` skips the peer and does not count it;
+the writer holds its ping. `NotReady` is not a connection failure — a peer may
+legally ping us mid-handshake, and the answer is silence, not a hang-up.
+
+That rule cannot be absolute, because **our `verack` is what makes a peer
+Ready**: gating it would gate it on itself, and no handshake would ever
+complete. `PeerTable::answer_handshake` is the one way past, and it is open only
+to a peer in `AwaitingVerack` — so the exception cannot be reached from any other
+state, by any other message.
+
+Their `verack` also *starts* the keep-alive. The writer's timer is the only thing
+that pings, it fires once per `PING_INTERVAL`, and nothing wakes it early; a peer
+that has just finished a handshake would otherwise wait out a full interval in
+silence. So the reader enqueues the first ping as it advances the peer to Ready.
+
+Until Ready, then, a connection has sent exactly one message — our `version` —
+and answered exactly one, with a `verack`.
 
 ### Who a connection is talking to
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,6 +76,13 @@ Delivery is `try_send`, never a blocking send: one stalled socket must not hold
 the node's lock and stop delivery to everyone else. A peer whose queue is full
 past `OUTBOUND_QUEUE` (128 messages) is **dropped**, not buffered.
 
+Delivery is also gated on **Ready**: `send_to` and `broadcast` queue nothing for
+a peer that has not identified itself, and the writer holds its ping. Only
+`answer_handshake` — our `verack` — goes out before Ready, because it is what
+makes the peer Ready. `send_to` reports `NotReady` rather than failing, since
+declining to answer an unidentified peer is the rule working, not a broken
+connection.
+
 Dropping it is not on its own enough to end the connection, and the reason is
 worth knowing: `mpsc` hands the writer every *buffered* message before it ever
 reports `Disconnected`, so a writer whose queue was full goes on writing to the
@@ -127,8 +134,11 @@ per-read timeout would never fire on it. Failing it ends the connection through
 the same path as any other read error, so the slot and the `recv_buffer` go with
 it.
 
-Relay is **not** yet gated on Ready: the keep-alive ping and the pong that
-answers one still go out mid-handshake. That gate is its own change.
+Until Ready, a connection has sent exactly one message — our `version` — and
+answered exactly one, with a `verack`. Nothing else, in either direction, is
+queued or written. Their `verack` is also what starts the keep-alive: the writer's
+timer would otherwise not fire for a full `PING_INTERVAL`, and nothing wakes it,
+so the reader enqueues the first ping as it advances the peer to Ready.
 
 ### Who a connection is talking to
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -224,9 +224,11 @@ Bitcoin · 🅧 deferred out of v1 by [ADR-0001](adr/0001-v1-scope.md).
   blocking syscall, and holding the node across it would stall every peer behind
   a slow pipe.
 - **Ready peer** ✅ — a peer whose `Handshake` has reached `Ready`, meaning both
-  its `version` and its `verack` have arrived. Built (M2). Gating relay on it is
-  separate work — today the keep-alive ping and the pong that answers one still
-  go out mid-handshake.
+  its `version` and its `verack` have arrived. Built (M2). **Only Ready peers are
+  sent anything**: `send_to` reports `Delivered::NotReady` and queues nothing,
+  `broadcast` skips and does not count them, and the writer holds its ping. The
+  lone exception is `answer_handshake`, carrying the `verack` that makes a peer
+  Ready in the first place.
 - **Reorg** ✅ (ADR-0012) — switching to a heavier branch. Disconnect back to the
   fork point restoring outputs from each block's **undo record**, then connect
   forward. Cost is proportional to reorg *depth*, not chain height. Not optional:

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -225,10 +225,9 @@ Bitcoin · 🅧 deferred out of v1 by [ADR-0001](adr/0001-v1-scope.md).
   a slow pipe.
 - **Ready peer** ✅ — a peer whose `Handshake` has reached `Ready`, meaning both
   its `version` and its `verack` have arrived. Built (M2). **Only Ready peers are
-  sent anything**: `send_to` reports `Delivered::NotReady` and queues nothing,
-  `broadcast` skips and does not count them, and the writer holds its ping. The
-  lone exception is `answer_handshake`, carrying the `verack` that makes a peer
-  Ready in the first place.
+  sent anything** — see
+  [ARCHITECTURE](ARCHITECTURE.md#the-handshake) for the gate and its one
+  exception.
 - **Reorg** ✅ (ADR-0012) — switching to a heavier branch. Disconnect back to the
   fork point restoring outputs from each block's **undo record**, then connect
   forward. Cost is proportional to reorg *depth*, not chain height. Not optional:

--- a/src/node.rs
+++ b/src/node.rs
@@ -70,6 +70,17 @@ pub enum Identity {
     AlreadyConnected,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Delivered {
+    Yes,
+    /// The peer has not identified itself, so nothing was queued. Not a failure
+    /// of the connection — it is the point.
+    NotReady,
+    /// No such peer, or one whose writer has gone or fallen too far behind. In
+    /// the latter case it is no longer in the table.
+    Gone,
+}
+
 #[derive(Debug, Default)]
 pub struct PeerTable {
     peers: HashMap<PeerId, PeerHandle>,
@@ -169,27 +180,45 @@ impl PeerTable {
         self.peers.keys().copied().collect()
     }
 
-    pub fn send_to(&mut self, id: PeerId, message: Vec<u8>) -> bool {
-        let Some(peer) = self.peers.get(&id) else {
-            return false;
-        };
-
-        match peer.outbound.try_send(message) {
-            Ok(()) => true,
-            Err(_) => {
-                self.peers.remove(&id);
-                false
-            }
+    pub fn send_to(&mut self, id: PeerId, message: Vec<u8>) -> Delivered {
+        match self.handshake_of(id) {
+            Some(handshake) if handshake.is_ready() => self.queue(id, message),
+            Some(_) => Delivered::NotReady,
+            None => Delivered::Gone,
         }
+    }
+
+    /// The one message that legitimately precedes Ready: our `verack` answers
+    /// their `version`, so waiting for Ready here would wait on itself.
+    pub fn answer_handshake(&mut self, id: PeerId, message: Vec<u8>) -> Delivered {
+        self.queue(id, message)
     }
 
     /// `try_send`, because a blocking send would hold the node's lock on one
     /// stalled socket and stop delivery to everyone else.
+    fn queue(&mut self, id: PeerId, message: Vec<u8>) -> Delivered {
+        let Some(peer) = self.peers.get(&id) else {
+            return Delivered::Gone;
+        };
+
+        match peer.outbound.try_send(message) {
+            Ok(()) => Delivered::Yes,
+            Err(TrySendError::Full(_)) | Err(TrySendError::Disconnected(_)) => {
+                self.peers.remove(&id);
+                Delivered::Gone
+            }
+        }
+    }
+
     pub fn broadcast(&mut self, message: &[u8]) -> usize {
         let mut delivered = 0;
         let mut failed = Vec::new();
 
         for (id, peer) in &self.peers {
+            if !peer.handshake.is_ready() {
+                continue;
+            }
+
             match peer.outbound.try_send(message.to_vec()) {
                 Ok(()) => delivered += 1,
                 Err(TrySendError::Full(_)) | Err(TrySendError::Disconnected(_)) => failed.push(*id),
@@ -322,6 +351,20 @@ mod tests {
         }
     }
 
+    fn a_ready_peer(table: &mut PeerTable, port: u16) -> (PeerId, Receiver<Vec<u8>>) {
+        let (id, queued) = a_peer(table, port);
+        shake_hands(table, id);
+        (id, queued)
+    }
+
+    fn shake_hands(table: &mut PeerTable, id: PeerId) {
+        for event in [HandshakeEvent::Version, HandshakeEvent::Verack] {
+            table
+                .advance_handshake(id, event)
+                .expect("a fresh peer should complete a handshake");
+        }
+    }
+
     fn a_peer(table: &mut PeerTable, port: u16) -> (PeerId, Receiver<Vec<u8>>) {
         let (outbound, queued) = sync_channel(OUTBOUND_QUEUE);
         let id = table
@@ -445,7 +488,7 @@ mod tests {
     fn broadcast_reaches_every_peer() {
         let mut table = PeerTable::default();
         let queues: Vec<_> = (0..3)
-            .map(|index| a_peer(&mut table, 5000 + index).1)
+            .map(|index| a_ready_peer(&mut table, 5000 + index).1)
             .collect();
 
         assert_eq!(3, table.broadcast(b"a block"));
@@ -459,10 +502,13 @@ mod tests {
     #[test]
     fn send_to_reaches_exactly_one_peer() {
         let mut table = PeerTable::default();
-        let (first, to_first) = a_peer(&mut table, 5000);
-        let (_, to_second) = a_peer(&mut table, 5001);
+        let (first, to_first) = a_ready_peer(&mut table, 5000);
+        let (_, to_second) = a_ready_peer(&mut table, 5001);
 
-        assert!(table.send_to(first, b"just for you".to_vec()));
+        assert_eq!(
+            Delivered::Yes,
+            table.send_to(first, b"just for you".to_vec())
+        );
 
         assert_eq!(b"just for you".to_vec(), to_first.try_recv().unwrap());
         assert!(
@@ -472,23 +518,91 @@ mod tests {
     }
 
     #[test]
+    fn broadcast_passes_over_a_peer_still_shaking_hands() {
+        let mut table = PeerTable::default();
+        let (_, to_ready) = a_ready_peer(&mut table, 5000);
+        let (_, to_halfway) = a_peer(&mut table, 5001);
+
+        assert_eq!(
+            1,
+            table.broadcast(b"a block"),
+            "it reports who it reached, not who it holds"
+        );
+
+        assert_eq!(b"a block".to_vec(), to_ready.try_recv().unwrap());
+        assert!(
+            to_halfway.try_recv().is_err(),
+            "a peer that has not identified itself gets nothing"
+        );
+        assert_eq!(2, table.len(), "and is not dropped for it");
+    }
+
+    #[test]
+    fn a_peer_becoming_ready_starts_receiving_broadcasts() {
+        let mut table = PeerTable::default();
+        let (id, queued) = a_peer(&mut table, 5000);
+
+        assert_eq!(0, table.broadcast(b"too early"));
+
+        shake_hands(&mut table, id);
+
+        assert_eq!(1, table.broadcast(b"right on time"));
+        assert_eq!(
+            vec![b"right on time".to_vec()],
+            std::iter::from_fn(|| queued.try_recv().ok()).collect::<Vec<_>>(),
+            "nothing from before Ready may have been buffered for later"
+        );
+    }
+
+    #[test]
+    fn send_to_a_peer_still_shaking_hands_delivers_nothing_and_keeps_it() {
+        let mut table = PeerTable::default();
+        let (id, queued) = a_peer(&mut table, 5000);
+
+        assert_eq!(
+            Delivered::NotReady,
+            table.send_to(id, b"too early".to_vec())
+        );
+
+        assert!(queued.try_recv().is_err());
+        assert_eq!(1, table.len(), "refusing to send is not refusing the peer");
+    }
+
+    #[test]
+    fn the_handshakes_own_reply_goes_out_before_the_peer_is_ready() {
+        let mut table = PeerTable::default();
+        let (id, queued) = a_peer(&mut table, 5000);
+        table
+            .advance_handshake(id, HandshakeEvent::Version)
+            .unwrap();
+
+        // Our verack is what makes them Ready, so gating it on Ready would be
+        // the handshake waiting on itself.
+        assert_eq!(
+            Delivered::Yes,
+            table.answer_handshake(id, b"a verack".to_vec())
+        );
+        assert_eq!(b"a verack".to_vec(), queued.try_recv().unwrap());
+    }
+
+    #[test]
     fn send_to_an_unknown_peer_delivers_nothing() {
         let mut table = PeerTable::default();
-        let (_, to_first) = a_peer(&mut table, 5000);
+        let (_, to_first) = a_ready_peer(&mut table, 5000);
 
-        assert!(!table.send_to(404, b"nobody".to_vec()));
+        assert_eq!(Delivered::Gone, table.send_to(404, b"nobody".to_vec()));
         assert!(to_first.try_recv().is_err());
     }
 
     #[test]
     fn a_peer_that_never_drains_does_not_hold_up_the_others() {
         let mut table = PeerTable::default();
-        let (stalled, never_drained) = a_peer(&mut table, 5000);
-        let (_, to_second) = a_peer(&mut table, 5001);
-        let (_, to_third) = a_peer(&mut table, 5002);
+        let (stalled, never_drained) = a_ready_peer(&mut table, 5000);
+        let (_, to_second) = a_ready_peer(&mut table, 5001);
+        let (_, to_third) = a_ready_peer(&mut table, 5002);
 
         for _ in 0..OUTBOUND_QUEUE {
-            assert!(table.send_to(stalled, b"backlog".to_vec()));
+            assert_eq!(Delivered::Yes, table.send_to(stalled, b"backlog".to_vec()));
         }
 
         assert_eq!(
@@ -506,17 +620,19 @@ mod tests {
     #[test]
     fn a_peers_queue_does_not_grow_past_the_bound() {
         let mut table = PeerTable::default();
-        let (stalled, never_drained) = a_peer(&mut table, 5000);
+        let (stalled, never_drained) = a_ready_peer(&mut table, 5000);
 
         for queued_so_far in 0..OUTBOUND_QUEUE {
-            assert!(
+            assert_eq!(
+                Delivered::Yes,
                 table.send_to(stalled, b"backlog".to_vec()),
                 "the bound is {OUTBOUND_QUEUE}, so message {queued_so_far} should fit"
             );
         }
 
-        assert!(
-            !table.send_to(stalled, b"one too many".to_vec()),
+        assert_eq!(
+            Delivered::Gone,
+            table.send_to(stalled, b"one too many".to_vec()),
             "a queue past {OUTBOUND_QUEUE} is unbounded buffering, not backpressure"
         );
         assert!(table.is_empty(), "a peer that cannot keep up is dropped");
@@ -531,10 +647,10 @@ mod tests {
     #[test]
     fn a_peer_whose_writer_is_gone_is_dropped() {
         let mut table = PeerTable::default();
-        let (id, queued) = a_peer(&mut table, 5000);
+        let (id, queued) = a_ready_peer(&mut table, 5000);
         drop(queued);
 
-        assert!(!table.send_to(id, b"into the void".to_vec()));
+        assert_eq!(Delivered::Gone, table.send_to(id, b"into the void".to_vec()));
         assert!(table.is_empty(), "a peer with no writer is not a peer");
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -73,11 +73,7 @@ pub enum Identity {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Delivered {
     Yes,
-    /// The peer has not identified itself, so nothing was queued. Not a failure
-    /// of the connection — it is the point.
     NotReady,
-    /// No such peer, or one whose writer has gone or fallen too far behind. In
-    /// the latter case it is no longer in the table.
     Gone,
 }
 
@@ -188,10 +184,15 @@ impl PeerTable {
         }
     }
 
-    /// The one message that legitimately precedes Ready: our `verack` answers
-    /// their `version`, so waiting for Ready here would wait on itself.
+    /// The only send that may precede Ready, and only from the one state that
+    /// needs it: our `verack` is what carries the peer out of `AwaitingVerack`,
+    /// so gating it on Ready would gate it on itself.
     pub fn answer_handshake(&mut self, id: PeerId, message: Vec<u8>) -> Delivered {
-        self.queue(id, message)
+        match self.handshake_of(id) {
+            Some(Handshake::AwaitingVerack) => self.queue(id, message),
+            Some(_) => Delivered::NotReady,
+            None => Delivered::Gone,
+        }
     }
 
     /// `try_send`, because a blocking send would hold the node's lock on one
@@ -212,21 +213,11 @@ impl PeerTable {
 
     pub fn broadcast(&mut self, message: &[u8]) -> usize {
         let mut delivered = 0;
-        let mut failed = Vec::new();
 
-        for (id, peer) in &self.peers {
-            if !peer.handshake.is_ready() {
-                continue;
+        for id in self.ids() {
+            if self.send_to(id, message.to_vec()) == Delivered::Yes {
+                delivered += 1;
             }
-
-            match peer.outbound.try_send(message.to_vec()) {
-                Ok(()) => delivered += 1,
-                Err(TrySendError::Full(_)) | Err(TrySendError::Disconnected(_)) => failed.push(*id),
-            }
-        }
-
-        for id in failed {
-            self.peers.remove(&id);
         }
 
         delivered
@@ -576,13 +567,30 @@ mod tests {
             .advance_handshake(id, HandshakeEvent::Version)
             .unwrap();
 
-        // Our verack is what makes them Ready, so gating it on Ready would be
-        // the handshake waiting on itself.
         assert_eq!(
             Delivered::Yes,
             table.answer_handshake(id, b"a verack".to_vec())
         );
         assert_eq!(b"a verack".to_vec(), queued.try_recv().unwrap());
+    }
+
+    #[rstest]
+    #[case::before_their_version(Handshake::AwaitingVersion)]
+    #[case::after_the_handshake(Handshake::Ready)]
+    fn the_handshake_door_opens_only_for_the_state_that_needs_it(#[case] state: Handshake) {
+        let mut table = PeerTable::default();
+        let (id, queued) = a_peer(&mut table, 5000);
+        if state == Handshake::Ready {
+            shake_hands(&mut table, id);
+        }
+
+        // An escape hatch wide enough for any state is not an exception, it is
+        // the gate with a second way round it.
+        assert_eq!(
+            Delivered::NotReady,
+            table.answer_handshake(id, b"not a verack".to_vec())
+        );
+        assert!(queued.try_recv().is_err());
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -7,7 +7,7 @@ use crate::messages::pong::Pong;
 use crate::messages::verack::Verack;
 use crate::messages::version::Version;
 use crate::node::{
-    record, Handshake, HandshakeEvent, Identity, Origin, PeerId, Refused, SharedNode,
+    record, Delivered, Handshake, HandshakeEvent, Identity, Origin, PeerId, Refused, SharedNode,
     OUTBOUND_QUEUE,
 };
 use anyhow::{anyhow, Result};
@@ -119,10 +119,24 @@ impl Registered {
             .peers
             .send_to(self.id, message);
 
-        if reached {
-            Ok(())
-        } else {
-            Err(anyhow!("peer cannot keep up with its own replies"))
+        // NotReady is the gate doing its job, not a broken connection: we owe a
+        // peer that has not identified itself nothing.
+        match reached {
+            Delivered::Yes | Delivered::NotReady => Ok(()),
+            Delivered::Gone => Err(anyhow!("peer cannot keep up with its own replies")),
+        }
+    }
+
+    fn answer_handshake(&self, message: Vec<u8>) -> Result<()> {
+        match self
+            .node
+            .lock()
+            .expect("node lock poisoned")
+            .peers
+            .answer_handshake(self.id, message)
+        {
+            Delivered::Yes => Ok(()),
+            other => Err(anyhow!("could not answer the handshake: {other:?}")),
         }
     }
 
@@ -148,6 +162,21 @@ impl Registered {
             .peers
             .handshake_of(self.id)
             .is_some_and(Handshake::is_ready)
+    }
+
+    /// A read-only view for the writer thread, which cannot hold the
+    /// registration itself — the table's sender must be the only one.
+    fn watching_readiness(&self) -> impl Fn() -> bool {
+        let node = Arc::clone(&self.node);
+        let id = self.id;
+
+        move || {
+            node.lock()
+                .expect("node lock poisoned")
+                .peers
+                .handshake_of(id)
+                .is_some_and(Handshake::is_ready)
+        }
     }
 }
 
@@ -190,7 +219,9 @@ fn handle_connection(
     ));
 
     let ours = Message::new(Version::new(nonce, host_address))?.get_raw_format()?;
-    let writer = thread::spawn(move || write_loop(&write_half.0, queued, PING_INTERVAL, ours));
+    let ready = registered.watching_readiness();
+    let writer =
+        thread::spawn(move || write_loop(&write_half.0, queued, PING_INTERVAL, ours, ready));
 
     let read_result = read_loop(stream, &registered, handshake_timeout);
 
@@ -209,15 +240,18 @@ fn write_loop<W: Write>(
     queued: Receiver<Vec<u8>>,
     ping_interval: Duration,
     opening: Vec<u8>,
+    ready: impl Fn() -> bool,
 ) -> Result<()> {
     // Ahead of the queue, not in it, so nothing we enqueue can precede it.
     writer.write_all(&opening)?;
 
-    let mut next_ping = Instant::now();
+    let mut next_ping = Instant::now() + ping_interval;
 
     loop {
         if Instant::now() >= next_ping {
-            writer.write_all(&Message::new(Ping::new())?.get_raw_format()?)?;
+            if ready() {
+                writer.write_all(&Message::new(Ping::new())?.get_raw_format()?)?;
+            }
             next_ping = Instant::now() + ping_interval;
         }
 
@@ -310,11 +344,16 @@ fn handle_messages(registered: &Registered, message: MessageReceived) -> Result<
                 "{} speaks protocol {} and listens on {}",
                 registered.address, peer.protocol_version, peer.listen_address
             ));
-            registered.deliver(Message::new(Verack)?.get_raw_format()?)?;
+            registered.answer_handshake(Message::new(Verack)?.get_raw_format()?)?;
         }
         VerackMessage => {
             registered.advance_handshake(HandshakeEvent::Verack)?;
             registered.record(format!("Handshake with {} complete", registered.address));
+
+            // The writer's timer only fires every PING_INTERVAL, and nothing
+            // else would wake it, so becoming Ready is what starts the
+            // keep-alive rather than the peer waiting out an interval for it.
+            registered.deliver(Message::new(Ping::new())?.get_raw_format()?)?;
         }
         PingMessage(ping) => {
             registered.record(format!("Ping received {ping:?}"));
@@ -371,19 +410,33 @@ mod tests {
     }
 
     #[test]
-    fn the_opening_message_precedes_the_first_ping_which_does_not_wait_for_the_interval() {
+    fn a_connection_opens_with_its_version_and_nothing_else() {
         let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
         drop(outbound);
 
         let mut output = Vec::new();
-        write_loop(&mut output, queued, NEVER, framed_version()).unwrap();
+        write_loop(&mut output, queued, Duration::ZERO, framed_version(), || false).unwrap();
 
         assert!(
-            matches!(
-                parse_all(&output).as_slice(),
-                [VersionMessage(_), PingMessage(_)]
-            ),
-            "a new connection identifies itself first, then pings at once rather than after an hour"
+            matches!(parse_all(&output).as_slice(), [VersionMessage(_)]),
+            "a peer that has not identified itself is owed nothing but our version, \
+             and a zero interval means the timer had every chance to fire"
+        );
+    }
+
+    #[test]
+    fn the_keep_alive_starts_only_once_the_peer_has_identified_itself() {
+        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
+        drop(outbound);
+
+        let mut output = Vec::new();
+        write_loop(&mut output, queued, Duration::ZERO, framed_version(), || true).unwrap();
+
+        assert!(
+            parse_all(&output)
+                .iter()
+                .any(|message| matches!(message, PingMessage(_))),
+            "a Ready peer should be pinged"
         );
     }
 
@@ -402,20 +455,20 @@ mod tests {
         });
 
         let mut output = Vec::new();
-        write_loop(&mut output, queued, NEVER, Vec::new()).unwrap();
+        write_loop(&mut output, queued, NEVER, Vec::new(), || true).unwrap();
         sender.join().unwrap();
 
         match parse_all(&output).as_slice() {
-            [PingMessage(_), PongMessage(pong)] => assert_eq!(nonce, pong.payload.nonce),
-            other => panic!("expected the opening ping then the enqueued pong, got {other:?}"),
+            [PongMessage(pong)] => assert_eq!(nonce, pong.payload.nonce),
+            other => panic!("expected the enqueued pong, got {other:?}"),
         }
     }
 
     #[test]
     fn a_stalled_write_ends_the_connection_rather_than_blocking_forever() {
-        /// Takes the opening ping, then behaves like a socket whose write
+        /// Takes the opening version, then behaves like a socket whose write
         /// timeout has expired — so the failure under test is the *queued*
-        /// message, not the ping.
+        /// message, not the opening one.
         #[derive(Default)]
         struct AcceptsThenStalls {
             taken: usize,
@@ -441,8 +494,14 @@ mod tests {
         // Dropping the peer cannot end this connection on its own: mpsc hands
         // the writer every buffered message before it ever reports
         // Disconnected, so the writer must give up on the socket itself.
-        write_loop(AcceptsThenStalls::default(), queued, NEVER, Vec::new())
-            .expect_err("a write that cannot proceed must end the connection");
+        write_loop(
+            AcceptsThenStalls::default(),
+            queued,
+            NEVER,
+            framed_version(),
+            || true,
+        )
+        .expect_err("a write that cannot proceed must end the connection");
     }
 
     #[test]
@@ -507,7 +566,7 @@ mod tests {
         });
 
         let mut output = Vec::new();
-        write_loop(&mut output, queued, interval, Vec::new()).unwrap();
+        write_loop(&mut output, queued, interval, Vec::new(), || true).unwrap();
         holder.join().unwrap();
 
         let pings = parse_all(&output).len();
@@ -525,8 +584,24 @@ mod tests {
     }
 
     #[test]
+    fn a_ping_from_a_peer_that_has_not_identified_itself_is_not_answered() {
+        let (registered, queued) = a_registered_peer();
+
+        process_incoming_bytes(&registered, &mut Vec::new(), &framed_ping().0)
+            .expect("declining to answer is not a broken connection");
+
+        assert!(
+            queued.try_recv().is_err(),
+            "we owe a peer that has not said who it is nothing at all"
+        );
+    }
+
+    #[test]
     fn an_inbound_ping_is_answered_with_a_pong_on_the_outbound_channel() {
         let (registered, queued) = a_registered_peer();
+        identify(&registered);
+        while queued.try_recv().is_ok() {}
+
         let mut recv_buffer = Vec::new();
         let (ping, nonce) = framed_ping();
 
@@ -579,6 +654,9 @@ mod tests {
         }
 
         let (registered, queued) = a_registered_peer();
+        identify(&registered);
+        while queued.try_recv().is_ok() {}
+
         let (ping, nonce) = framed_ping();
         let reader = InterruptsOnce {
             ping,
@@ -698,15 +776,20 @@ mod tests {
             matches!(next_message(&mut peer, &mut buffer), VersionMessage(_)),
             "a connection should open by identifying itself"
         );
+
+        peer.write_all(&framed_version()).unwrap();
+        assert!(matches!(next_reply(&mut peer, &mut buffer), VerackMessage));
+        peer.write_all(&framed(Verack)).unwrap();
+
         assert!(
             matches!(next_message(&mut peer, &mut buffer), PingMessage(_)),
-            "and then ping its peer"
+            "and ping it once it has identified itself"
         );
 
         let (ping, nonce) = framed_ping();
         peer.write_all(&ping).unwrap();
 
-        match next_message(&mut peer, &mut buffer) {
+        match next_reply(&mut peer, &mut buffer) {
             PongMessage(pong) => assert_eq!(nonce, pong.payload.nonce),
             other => panic!("expected a pong for our ping, got {other:?}"),
         }
@@ -792,7 +875,12 @@ mod tests {
         process_incoming_bytes(&registered, &mut recv_buffer, &framed(Verack)).unwrap();
 
         assert!(registered.is_ready());
-        assert!(queued.try_recv().is_err(), "a verack is not itself answered");
+        let started = queued.try_recv().expect("becoming Ready starts the keep-alive");
+        assert!(
+            matches!(parse_all(&started).as_slice(), [PingMessage(_)]),
+            "the writer's timer would not fire for a whole interval on its own"
+        );
+        assert!(queued.try_recv().is_err(), "one handshake, one opening ping");
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -119,11 +119,10 @@ impl Registered {
             .peers
             .send_to(self.id, message);
 
-        // NotReady is the gate doing its job, not a broken connection: we owe a
-        // peer that has not identified itself nothing.
         match reached {
+            // Declining to answer an unidentified peer is the gate working.
             Delivered::Yes | Delivered::NotReady => Ok(()),
-            Delivered::Gone => Err(anyhow!("peer cannot keep up with its own replies")),
+            Delivered::Gone => Err(anyhow!("peer is gone, or too far behind to answer")),
         }
     }
 
@@ -156,28 +155,25 @@ impl Registered {
     }
 
     fn is_ready(&self) -> bool {
-        self.node
-            .lock()
-            .expect("node lock poisoned")
-            .peers
-            .handshake_of(self.id)
-            .is_some_and(Handshake::is_ready)
+        is_ready(&self.node, self.id)
     }
 
-    /// A read-only view for the writer thread, which cannot hold the
-    /// registration itself — the table's sender must be the only one.
-    fn watching_readiness(&self) -> impl Fn() -> bool {
+    /// The writer thread cannot hold the registration — the table's sender has
+    /// to be the only one — so it gets this instead.
+    fn readiness(&self) -> impl Fn() -> bool {
         let node = Arc::clone(&self.node);
         let id = self.id;
 
-        move || {
-            node.lock()
-                .expect("node lock poisoned")
-                .peers
-                .handshake_of(id)
-                .is_some_and(Handshake::is_ready)
-        }
+        move || is_ready(&node, id)
     }
+}
+
+fn is_ready(node: &SharedNode, id: PeerId) -> bool {
+    node.lock()
+        .expect("node lock poisoned")
+        .peers
+        .handshake_of(id)
+        .is_some_and(Handshake::is_ready)
 }
 
 impl Drop for Registered {
@@ -219,7 +215,7 @@ fn handle_connection(
     ));
 
     let ours = Message::new(Version::new(nonce, host_address))?.get_raw_format()?;
-    let ready = registered.watching_readiness();
+    let ready = registered.readiness();
     let writer =
         thread::spawn(move || write_loop(&write_half.0, queued, PING_INTERVAL, ours, ready));
 
@@ -350,9 +346,7 @@ fn handle_messages(registered: &Registered, message: MessageReceived) -> Result<
             registered.advance_handshake(HandshakeEvent::Verack)?;
             registered.record(format!("Handshake with {} complete", registered.address));
 
-            // The writer's timer only fires every PING_INTERVAL, and nothing
-            // else would wake it, so becoming Ready is what starts the
-            // keep-alive rather than the peer waiting out an interval for it.
+            // Nothing else wakes the writer, whose timer is an interval away.
             registered.deliver(Message::new(Ping::new())?.get_raw_format()?)?;
         }
         PingMessage(ping) => {
@@ -425,7 +419,7 @@ mod tests {
     }
 
     #[test]
-    fn the_keep_alive_starts_only_once_the_peer_has_identified_itself() {
+    fn a_ready_peer_is_pinged() {
         let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
         drop(outbound);
 

--- a/test/functional/test_connections.py
+++ b/test/functional/test_connections.py
@@ -4,13 +4,17 @@ from framework.p2p import address_of, expect_dialled
 
 def test_a_node_pings_whoever_dials_it(net):
     node = net.node("--host-address", "127.0.0.1:0")
+    peer = net.dial(node.listening_on())
 
-    assert net.dial(node.listening_on()).next_frame_of("ping").command == "ping"
+    peer.handshake()
+
+    assert peer.next_frame_of("ping").command == "ping"
 
 
 def test_a_node_answers_a_ping_with_a_pong_carrying_the_same_nonce(net):
     node = net.node("--host-address", "127.0.0.1:0")
     peer = net.dial(node.listening_on())
+    peer.handshake()
 
     peer.send(ping(0x0123456789ABCDEF))
 
@@ -38,6 +42,7 @@ def test_a_node_dials_every_address_it_was_given(net):
 def test_a_pong_is_accepted_and_does_not_provoke_another_pong(net):
     node = net.node("--host-address", "127.0.0.1:0")
     peer = net.dial(node.listening_on())
+    peer.handshake()
 
     opening = peer.next_frame_of("ping")
     peer.send(pong(opening.nonce))

--- a/test/functional/test_framing.py
+++ b/test/functional/test_framing.py
@@ -8,6 +8,7 @@ from framework.messages import ping
 def test_a_message_dribbled_one_byte_at_a_time_is_still_understood(net):
     node = net.node("--host-address", "127.0.0.1:0")
     peer = net.dial(node.listening_on())
+    peer.handshake()
 
     for byte in ping(0xDEADBEEF):
         peer.send(bytes([byte]))
@@ -19,6 +20,7 @@ def test_a_message_dribbled_one_byte_at_a_time_is_still_understood(net):
 def test_two_messages_arriving_in_one_read_are_both_answered(net):
     node = net.node("--host-address", "127.0.0.1:0")
     peer = net.dial(node.listening_on())
+    peer.handshake()
 
     peer.send(ping(11) + ping(22))
 
@@ -29,6 +31,7 @@ def test_a_second_message_split_across_the_first_read_is_not_lost(net):
     """The tail of one read holds a whole message plus the head of the next."""
     node = net.node("--host-address", "127.0.0.1:0")
     peer = net.dial(node.listening_on())
+    peer.handshake()
 
     stream = ping(101) + ping(202)
     peer.send(stream[:-4])

--- a/test/functional/test_identity.py
+++ b/test/functional/test_identity.py
@@ -8,7 +8,7 @@ because whichever binds second is dialled by nobody.
 
 import pytest
 
-from framework.messages import ping, version
+from framework.messages import ping, verack, version
 from framework.p2p import ELSEWHERE, a_free_address, address_of, expect_dialled
 
 # A node's nonce is 64 random bits, so these sit either side of it. Picking them
@@ -16,6 +16,19 @@ from framework.p2p import ELSEWHERE, a_free_address, address_of, expect_dialled
 # a 1-in-2^64 draw to happen.
 LOSING = 0
 WINNING = 2**64 - 1
+
+
+def still_a_peer(connection, nonce):
+    """Finish the handshake this connection opened, then prove it still works.
+
+    Nothing flows to a peer before Ready, so a surviving connection has to be
+    taken all the way through to say anything about it at all.
+    """
+    connection.next_frame_of("verack")
+    connection.send(verack())
+    connection.send(ping(nonce))
+
+    assert connection.pongs_within() == [nonce]
 
 
 def test_a_peer_claiming_the_nodes_own_nonce_is_hung_up_on(net):
@@ -81,8 +94,7 @@ def test_a_mutual_dial_settles_on_the_socket_the_larger_nonce_dialled(
         (it_dialled, we_dialled) if node_keeps_its_own_dial else (we_dialled, it_dialled)
     )
     dropped.expect_closed()
-    kept.send(ping(0xC0FFEE))
-    assert kept.pongs_within() == [0xC0FFEE], "exactly one connection survives"
+    still_a_peer(kept, 0xC0FFEE)
 
 
 def test_two_connections_under_one_nonce_never_both_survive(net):
@@ -99,8 +111,7 @@ def test_two_connections_under_one_nonce_never_both_survive(net):
     second.send(version(LOSING, ELSEWHERE))
 
     second.expect_closed()
-    first.send(ping(0xD00D))
-    assert first.pongs_within() == [0xD00D]
+    still_a_peer(first, 0xD00D)
 
 
 def test_a_different_nonce_is_a_different_peer(net):
@@ -116,5 +127,4 @@ def test_a_different_nonce_is_a_different_peer(net):
         peers.append(peer)
 
     for peer, nonce in zip(peers, (0xAAA, 0xBBB)):
-        peer.send(ping(nonce))
-        assert peer.pongs_within() == [nonce], "both peers should still be here"
+        still_a_peer(peer, nonce)

--- a/test/functional/test_ready_gate.py
+++ b/test/functional/test_ready_gate.py
@@ -1,0 +1,51 @@
+"""Nothing reaches a peer that has not said who it is.
+
+The one exception is the handshake's own traffic: our `version`, which opens
+every connection, and the `verack` that answers theirs. Gating those on Ready
+would be the handshake waiting on itself.
+"""
+
+from framework.messages import ping, verack, version
+from framework.p2p import ELSEWHERE
+
+
+def test_a_peer_that_has_not_identified_itself_is_sent_nothing(net):
+    node = net.node("--host-address", "127.0.0.1:0")
+    peer = net.dial(node.listening_on())
+
+    assert peer.next_frame().command == "version"
+    peer.send(ping(0xDEAD))
+
+    assert peer.frames_within() == [], (
+        "no pong for a peer we owe nothing, and no keep-alive either -- a "
+        "connection used to be pinged the moment it opened"
+    )
+
+
+def test_half_a_handshake_is_still_not_a_peer(net):
+    node = net.node("--host-address", "127.0.0.1:0")
+    peer = net.dial(node.listening_on())
+    peer.learn_nonce()
+
+    peer.send(version(0x51DE, ELSEWHERE))
+    assert peer.next_frame_of("verack").command == "verack"
+
+    peer.send(ping(0xDEAD))
+    assert peer.pongs_within() == [], "their verack has still not arrived"
+
+
+def test_the_same_connection_starts_being_answered_once_it_is_ready(net):
+    """No reconnect: the gate opens on the connection that was refused."""
+    node = net.node("--host-address", "127.0.0.1:0")
+    peer = net.dial(node.listening_on())
+    peer.learn_nonce()
+
+    peer.send(ping(0xEA71))
+    assert peer.pongs_within() == [], "too early"
+
+    peer.send(version(0x51DE, ELSEWHERE))
+    peer.next_frame_of("verack")
+    peer.send(verack())
+
+    peer.send(ping(0x1A7E))
+    assert peer.pongs_within() == [0x1A7E]


### PR DESCRIPTION
Closes #42.

> ⚠️ **Stacked on #47** (`feat/identity-by-version-nonce`). The base is that branch, so the diff here is only this ticket's three commits. #47 needs to go in first.

`send_to` queues nothing for a peer mid-handshake and reports `NotReady`; `broadcast` skips it and does not count it; the writer holds its ping.

### The trap in "gate everything"

**Our `verack` is what makes a peer Ready.** Gate it and it gates itself — no handshake ever completes and every connection dies at `HANDSHAKE_TIMEOUT`. So there has to be exactly one way past the gate.

`PeerTable::answer_handshake` is it, and after review it opens **only for a peer in `AwaitingVerack`**. Before that it took any bytes from any state, which made the exception exactly as wide as the gate — safe only because it happened to have one caller. Now it is self-limiting, and the arm that refuses everything else is exercised rather than dead.

`NotReady` is deliberately **not** a connection failure. A peer may legally ping us before identifying itself — ours did, until this commit — and the answer is silence, not a hang-up.

### Two things #42's criteria don't name

Both are in scope, and I'd rather flag them than have you find them:

**The keep-alive ping is gated too.** It's written directly by `write_loop`, bypassing the table, so gating only `broadcast`/`send_to` would leave "nothing is sent to a peer that has not identified itself" false. #40's PR explicitly deferred this here.

**Their `verack` now *starts* the keep-alive.** The writer's timer is the only thing that pings, fires once per `PING_INTERVAL` (11s), and nothing wakes it early — so a freshly handshaken peer would sit in silence for a full interval. The reader enqueues the first ping as it advances the peer to Ready. The writer's own timer consequently starts at `now + interval` rather than `now`, or the two would land back to back.

### The test churn is the point

Every functional test that used to ping the node and expect a pong now has to handshake first. That diff *is* the guarantee: an unidentified peer no longer gets one.

| Mutation | Caught by |
|---|---|
| `send_to` ignores the handshake | 2 Rust + 3 functional |
| `broadcast` ignores the handshake | 2 Rust |
| The writer pings regardless of readiness | 1 Rust |
| The verack is gated like everything else | 3 Rust |
| Becoming Ready does not start the keep-alive | 2 Rust + 3 functional |
| `broadcast` bypasses `send_to`'s gate | 2 Rust |
| The handshake door opens from any state | 2 Rust |

The ping-gate mutation is Rust-only on purpose: at an 11s interval the stray ping falls outside the suite's 3s impatience window, so only a zero-interval unit test can see it.

### One judgement call for you

The reviewer argued the gate deserves its own ADR. I didn't write one — the *decision* was the ticket's, and what's left is a consequence rather than a choice between designs. It's stated once, in ARCHITECTURE's handshake section, with CLAUDE.md and the glossary pointing there. Say the word if you'd rather it were ADR-0016.

178 Rust tests, 38 functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)