### PR TITLE
Keep dialling a configured peer, backing off when it will not answer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ CI (`.github/workflows/tests.yml`) runs both suites on pushes/PRs to `main`, as 
 
 The node is a small P2P server modeled on Bitcoin's message framing. `main.rs` binds the listener (so a bad address or a taken port fails the process, not a detached thread), then runs `protocol::listen` on one thread and gives each configured address a `protocol::keep_connected` thread. Inbound connections go through `spawn_connection`, which gives each its own thread — so the accept loop is never blocked, and one peer's failure is logged rather than taking the listener down.
 
-`keep_connected` **is** its connection's thread: it dials, serves the connection to completion, backs off, and dials again. So a live connection cannot be redialled by construction, with no check to race. The backoff resets only when a connection *lasted* `Retry::settled` — [ADR-0016](docs/adr/0016-reconnecting-to-configured-peers.md) explains why "the TCP connect succeeded" is the wrong test, and it is the checked-in `config.toml` that proves it.
+`keep_connected` waits out its connection before dialling again, so a live one cannot be redialled — no check to race. The backoff resets only when a connection *lasted* `Retry::settled`, timed from the connect rather than from the attempt. [ADR-0016](docs/adr/0016-reconnecting-to-configured-peers.md) has both reasons; the checked-in `config.toml` is the counterexample that produced the first.
 
 `spawn_connection` registers the peer in `node.peers` before handing off, and a `Registered` guard removes it on any exit including a panic. A connection refused at `MAX_PEERS` is dropped there and never becomes a thread pair.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,9 @@ CI (`.github/workflows/tests.yml`) runs both suites on pushes/PRs to `main`, as 
 
 ## Architecture
 
-The node is a small P2P server modeled on Bitcoin's message framing. `main.rs` binds the listener (so a bad address or a taken port fails the process, not a detached thread), then runs `protocol::listen` on one thread and dials each configured peer. Both inbound and outbound connections go through `protocol::spawn_connection`, which gives each its own thread — so the accept loop is never blocked, and one peer's failure is logged rather than taking the listener down.
+The node is a small P2P server modeled on Bitcoin's message framing. `main.rs` binds the listener (so a bad address or a taken port fails the process, not a detached thread), then runs `protocol::listen` on one thread and gives each configured address a `protocol::keep_connected` thread. Inbound connections go through `spawn_connection`, which gives each its own thread — so the accept loop is never blocked, and one peer's failure is logged rather than taking the listener down.
+
+`keep_connected` **is** its connection's thread: it dials, serves the connection to completion, backs off, and dials again. So a live connection cannot be redialled by construction, with no check to race. The backoff resets only when a connection *lasted* `Retry::settled` — [ADR-0016](docs/adr/0016-reconnecting-to-configured-peers.md) explains why "the TCP connect succeeded" is the wrong test, and it is the checked-in `config.toml` that proves it.
 
 `spawn_connection` registers the peer in `node.peers` before handing off, and a `Registered` guard removes it on any exit including a panic. A connection refused at `MAX_PEERS` is dropped there and never becomes a thread pair.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,6 +160,12 @@ Why the tie-break is phrased over the nonce pair rather than from one node's
 point of view — and why "keep the one we dialled" loses both connections — is
 [ADR-0015](adr/0015-peer-identity-and-duplicate-connections.md).
 
+A configured address gets a **`keep_connected` thread** that is also its
+connection's thread: it dials, serves to completion, backs off, dials again.
+Nothing can redial a live connection, because the thread that would is inside
+it. The backoff resets on a connection that *lasted*, not on one that merely
+connected — [ADR-0016](adr/0016-reconnecting-to-configured-peers.md).
+
 The miner is one more thread, holding no lock while it grinds: it snapshots the
 mempool, builds a candidate block, releases the lock, and only re-acquires it to
 connect and broadcast a solved block.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,11 +160,11 @@ Why the tie-break is phrased over the nonce pair rather than from one node's
 point of view — and why "keep the one we dialled" loses both connections — is
 [ADR-0015](adr/0015-peer-identity-and-duplicate-connections.md).
 
-A configured address gets a **`keep_connected` thread** that is also its
-connection's thread: it dials, serves to completion, backs off, dials again.
-Nothing can redial a live connection, because the thread that would is inside
-it. The backoff resets on a connection that *lasted*, not on one that merely
-connected — [ADR-0016](adr/0016-reconnecting-to-configured-peers.md).
+A configured address gets a **`keep_connected` thread**: it dials, waits out the
+connection, backs off, dials again. Nothing can redial a live connection because
+the thread that would is blocked on it. The backoff resets on a connection that
+*lasted*, not on one that merely connected —
+[ADR-0016](adr/0016-reconnecting-to-configured-peers.md).
 
 The miner is one more thread, holding no lock while it grinds: it snapshots the
 mempool, builds a candidate block, releases the lock, and only re-acquires it to

--- a/docs/adr/0016-reconnecting-to-configured-peers.md
+++ b/docs/adr/0016-reconnecting-to-configured-peers.md
@@ -16,14 +16,19 @@ configuration is the counterexample.
 
 ## Decision
 
-One thread per configured address, and **that thread is the connection's
-thread** — it runs the connection to completion and only then considers
-redialling. A live connection therefore cannot be dialled a second time, by
-construction rather than by a check that could race.
+One thread per configured address. It dials, waits for the connection to end,
+backs off, and dials again — so a live connection cannot be dialled a second
+time, by construction rather than by a check that could race.
 
 The backoff doubles from `first` (1s) to `cap` (60s). It resets only when the
 connection **lasted at least `settled`** (10s). A connection shorter than that
 did not work, whatever the socket reported.
+
+*Lasted* is measured from the moment the socket connected, never from the moment
+the dial began. A dial that fails lasted no time at all, however long it spent
+failing: a blackholed address sits in `connect()` for around two minutes on
+Linux, and counting that as a long-lived connection would reset the backoff on
+precisely the peer it exists to back off.
 
 ## Why not reset on a successful connect
 

--- a/docs/adr/0016-reconnecting-to-configured-peers.md
+++ b/docs/adr/0016-reconnecting-to-configured-peers.md
@@ -1,0 +1,57 @@
+# ADR-0016 — A connection has to last before it resets the backoff
+
+- **Status:** Accepted
+- **Date:** 2026-08-08
+- **Deciders:** @matheusavi
+
+## Context
+
+`addresses_to_connect` was dialled once at boot. A peer down at that moment was
+lost until the process restarted, and so was one that dropped later. Retrying
+needs a backoff, or a peer that is simply gone becomes a busy loop.
+
+The usual rule is **grow on failure, reset on success**, where success means the
+TCP connect returned. That rule is wrong here, and the repo's own default
+configuration is the counterexample.
+
+## Decision
+
+One thread per configured address, and **that thread is the connection's
+thread** — it runs the connection to completion and only then considers
+redialling. A live connection therefore cannot be dialled a second time, by
+construction rather than by a check that could race.
+
+The backoff doubles from `first` (1s) to `cap` (60s). It resets only when the
+connection **lasted at least `settled`** (10s). A connection shorter than that
+did not work, whatever the socket reported.
+
+## Why not reset on a successful connect
+
+The checked-in `config.toml` points `host_address` and `addresses_to_connect` at
+the same address, so the default local setup dials *itself*. Since
+[ADR-0015](0015-peer-identity-and-duplicate-connections.md) that self-connection
+is recognised at the handshake and dropped — after the TCP connect succeeded.
+
+Under "reset on connect" the sequence is: connect (reset to 1s) → handshake →
+recognise our own nonce → drop → wait 1s → repeat. Forever, once per second,
+out of the box. The backoff would never grow, because every attempt "succeeds".
+
+The same shape covers a peer that accepts and immediately hangs up, whether
+broken or hostile: it would hold us at the shortest retry interval indefinitely.
+
+Requiring the connection to *last* removes both. A self-connection dies in
+milliseconds, so the backoff climbs to its cap and stays there; a real peer that
+runs for ten seconds resets it.
+
+## Consequences
+
+- A node dialling itself settles into a 60s retry rather than a 1/s loop. It
+  still retries, because "stop dialling an address that turned out to be us" is
+  identity work this ADR does not cover.
+- A peer whose connection legitimately ends inside 10s is redialled slightly
+  later than it might be. Nothing depends on the difference.
+- `settled` is a duration rather than "did it reach Ready". Both would work here;
+  a duration needs no signal threaded back out of the connection, and does not go
+  stale if what counts as established changes.
+- Discovery peers are out of scope. When #44 lands they will come and go by
+  design, and reconnecting to them is not the same intent.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,6 +43,7 @@ a number.
 | [0013](0013-persistence.md) | Persistence | Accepted |
 | [0014](0014-functional-test-suite.md) | Functional test suite: Python, driving real binaries | Accepted |
 | [0015](0015-peer-identity-and-duplicate-connections.md) | Peer identity is the version nonce, and duplicates break the tie by it | Accepted |
+| [0016](0016-reconnecting-to-configured-peers.md) | A connection has to last before it resets the backoff | Accepted |
 
 [TEMPLATE.md](TEMPLATE.md) is the starting point for a new record. It is not an
 ADR and holds no number.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -213,6 +213,9 @@ Bitcoin · 🅧 deferred out of v1 by [ADR-0001](adr/0001-v1-scope.md).
   starting a new handshake. A connection that has not reached Ready within
   `HANDSHAKE_TIMEOUT` (20s) is dropped — an absolute deadline, so a peer that
   dribbles bytes it never completes a handshake with cannot hold a slot open.
+- **Retry / backoff** ✅ (ADR-0016) — how a *configured* address is redialled:
+  doubling from 1s to a 60s cap, reset only by a connection that lasted at least
+  10s. Discovery peers are not redialled; they come and go by design.
 - **MAX_PEERS / OUTBOUND_QUEUE** ✅ — 32 connections, 128 queued messages each.
   At either limit the peer is **refused** or **dropped**, never made to wait: a
   blocking send would stall the whole node on one slow socket.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use crate::config::get_config;
 use crate::node::{record, Node};
-use crate::protocol::{connect, listen};
+use crate::protocol::{keep_connected, listen, Retry};
 use anyhow::{Context, Result};
 use std::net::TcpListener;
 use std::sync::Arc;
@@ -50,9 +50,8 @@ fn main() -> Result<()> {
     let handle = thread::spawn(move || listen(listener, listening_node));
 
     for addr in addresses_to_connect {
-        if let Err(e) = connect(addr, Arc::clone(&node)) {
-            record(&node, format!("Could not connect to {addr}: {e:#}"));
-        }
+        let node = Arc::clone(&node);
+        thread::spawn(move || keep_connected(addr, node, Retry::default()));
     }
 
     handle

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -30,8 +30,7 @@ const WRITE_TIMEOUT: Duration = Duration::from_secs(30);
 /// against a deadline it cannot see.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// How a configured peer is redialled. ADR-0016 covers `settled`, which is the
-/// only part that is not obvious.
+/// ADR-0016.
 #[derive(Clone, Copy, Debug)]
 pub struct Retry {
     pub first: Duration,
@@ -49,21 +48,39 @@ impl Default for Retry {
     }
 }
 
-/// Dials a configured address and keeps it dialled. This thread *is* the
-/// connection's thread, so it cannot redial one that is still alive.
 pub fn keep_connected(address: SocketAddr, node: SharedNode, retry: Retry) {
     let mut backoff = Backoff::new(retry.first, retry.cap);
 
     loop {
-        let opened = Instant::now();
-
-        match TcpStream::connect(address) {
-            Ok(stream) => serve_connection(stream, &node, Origin::Dialled),
-            Err(e) => record(&node, format!("Could not connect to {address}: {e}")),
-        }
-
-        thread::sleep(backoff.after(opened.elapsed(), retry.settled));
+        thread::sleep(backoff.after(dial(address, &node), retry.settled));
     }
+}
+
+/// Dials, serves the connection to completion, and reports how long it lasted.
+/// Waiting here is what keeps a live connection from being dialled twice.
+fn dial(address: SocketAddr, node: &SharedNode) -> Duration {
+    let stream = match TcpStream::connect(address) {
+        Ok(stream) => stream,
+        Err(e) => {
+            record(node, format!("Could not connect to {address}: {e:#}"));
+            // A dial that never connected lasted no time at all, however long
+            // it spent failing — a blackholed address can take a minute.
+            return Duration::ZERO;
+        }
+    };
+
+    let opened = Instant::now();
+
+    // Joined rather than run here, so a panic costs one connection instead of
+    // every future dial to this address.
+    if spawn_connection(stream, Arc::clone(node), Origin::Dialled)
+        .join()
+        .is_err()
+    {
+        record(node, format!("Connection with {address} panicked"));
+    }
+
+    opened.elapsed()
 }
 
 struct Backoff {
@@ -77,8 +94,7 @@ impl Backoff {
         Backoff { next: first, first, cap }
     }
 
-    /// ADR-0016: a connection that did not last is not a success, whatever the
-    /// socket said, or a peer that hangs up at once holds us at `first`.
+    // ADR-0016.
     fn after(&mut self, lasted: Duration, settled: Duration) -> Duration {
         if lasted >= settled {
             self.next = self.first;
@@ -94,7 +110,9 @@ impl Backoff {
 pub fn listen(listener: TcpListener, node: SharedNode) -> Result<()> {
     for stream in listener.incoming() {
         match stream {
-            Ok(stream) => spawn_connection(stream, Arc::clone(&node), Origin::Accepted),
+            Ok(stream) => {
+                spawn_connection(stream, Arc::clone(&node), Origin::Accepted);
+            }
             Err(e) => record(&node, format!("Could not accept a connection: {e}")),
         }
     }
@@ -102,8 +120,12 @@ pub fn listen(listener: TcpListener, node: SharedNode) -> Result<()> {
     Ok(())
 }
 
-fn spawn_connection(stream: TcpStream, node: SharedNode, origin: Origin) {
-    thread::spawn(move || serve_connection(stream, &node, origin));
+fn spawn_connection(
+    stream: TcpStream,
+    node: SharedNode,
+    origin: Origin,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || serve_connection(stream, &node, origin))
 }
 
 // Registration lives here, not in the call sites that dial and accept.
@@ -558,6 +580,30 @@ mod tests {
     }
 
     #[test]
+    fn a_dial_that_never_connected_lasted_no_time_at_all() {
+        let refused = a_free_port();
+
+        let lasted = dial(refused, &a_node());
+
+        // Not the time the *attempt* took: a blackholed address can sit in
+        // connect() for a minute, and treating that as a connection that lasted
+        // would reset the backoff on exactly the peer it exists to back off.
+        assert_eq!(Duration::ZERO, lasted);
+    }
+
+    #[test]
+    fn a_dial_that_connected_reports_how_long_it_was_served() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let hangs_up = thread::spawn(move || drop(listener.accept().unwrap()));
+
+        let lasted = dial(address, &a_node());
+        hangs_up.join().unwrap();
+
+        assert!(lasted > Duration::ZERO, "a connection that happened lasted");
+    }
+
+    #[test]
     fn a_backoff_grows_and_stops_at_its_cap() {
         let mut backoff = a_backoff();
 
@@ -797,6 +843,15 @@ mod tests {
                 reply => return reply,
             }
         }
+    }
+
+    /// An address nothing is listening on, so a dial to it is refused at once.
+    fn a_free_port() -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+
+        address
     }
 
     fn a_connected_pair() -> (TcpStream, TcpStream, SocketAddr) {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -30,11 +30,65 @@ const WRITE_TIMEOUT: Duration = Duration::from_secs(30);
 /// against a deadline it cannot see.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
 
-pub fn connect(addr: SocketAddr, node: SharedNode) -> Result<()> {
-    let stream = TcpStream::connect(addr)?;
-    spawn_connection(stream, node, Origin::Dialled);
+/// How a configured peer is redialled. ADR-0016 covers `settled`, which is the
+/// only part that is not obvious.
+#[derive(Clone, Copy, Debug)]
+pub struct Retry {
+    pub first: Duration,
+    pub cap: Duration,
+    pub settled: Duration,
+}
 
-    Ok(())
+impl Default for Retry {
+    fn default() -> Self {
+        Retry {
+            first: Duration::from_secs(1),
+            cap: Duration::from_secs(60),
+            settled: Duration::from_secs(10),
+        }
+    }
+}
+
+/// Dials a configured address and keeps it dialled. This thread *is* the
+/// connection's thread, so it cannot redial one that is still alive.
+pub fn keep_connected(address: SocketAddr, node: SharedNode, retry: Retry) {
+    let mut backoff = Backoff::new(retry.first, retry.cap);
+
+    loop {
+        let opened = Instant::now();
+
+        match TcpStream::connect(address) {
+            Ok(stream) => serve_connection(stream, &node, Origin::Dialled),
+            Err(e) => record(&node, format!("Could not connect to {address}: {e}")),
+        }
+
+        thread::sleep(backoff.after(opened.elapsed(), retry.settled));
+    }
+}
+
+struct Backoff {
+    next: Duration,
+    first: Duration,
+    cap: Duration,
+}
+
+impl Backoff {
+    fn new(first: Duration, cap: Duration) -> Self {
+        Backoff { next: first, first, cap }
+    }
+
+    /// ADR-0016: a connection that did not last is not a success, whatever the
+    /// socket said, or a peer that hangs up at once holds us at `first`.
+    fn after(&mut self, lasted: Duration, settled: Duration) -> Duration {
+        if lasted >= settled {
+            self.next = self.first;
+        }
+
+        let waiting = self.next;
+        self.next = (self.next * 2).min(self.cap);
+
+        waiting
+    }
 }
 
 pub fn listen(listener: TcpListener, node: SharedNode) -> Result<()> {
@@ -48,37 +102,36 @@ pub fn listen(listener: TcpListener, node: SharedNode) -> Result<()> {
     Ok(())
 }
 
-// Registration lives here, not in the two call sites that dial and accept.
 fn spawn_connection(stream: TcpStream, node: SharedNode, origin: Origin) {
-    thread::spawn(move || {
-        let peer = match stream.peer_addr() {
-            Ok(peer) => peer,
-            Err(e) => {
-                record(
-                    &node,
-                    format!("Dropping a connection with no resolvable peer address: {e}"),
-                );
-                return;
-            }
-        };
+    thread::spawn(move || serve_connection(stream, &node, origin));
+}
 
-        let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
-
-        let registered = match Registered::open(&node, peer, origin, outbound) {
-            Ok(registered) => registered,
-            Err(refusal) => {
-                record(
-                    &node,
-                    format!("Refusing a connection with {peer}: {refusal:?}"),
-                );
-                return;
-            }
-        };
-
-        if let Err(e) = handle_connection(stream, registered, queued, HANDSHAKE_TIMEOUT) {
-            record(&node, format!("Connection with {peer} ended: {e:#}"));
+// Registration lives here, not in the call sites that dial and accept.
+fn serve_connection(stream: TcpStream, node: &SharedNode, origin: Origin) {
+    let peer = match stream.peer_addr() {
+        Ok(peer) => peer,
+        Err(e) => {
+            record(
+                node,
+                format!("Dropping a connection with no resolvable peer address: {e}"),
+            );
+            return;
         }
-    });
+    };
+
+    let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
+
+    let registered = match Registered::open(node, peer, origin, outbound) {
+        Ok(registered) => registered,
+        Err(refusal) => {
+            record(node, format!("Refusing a connection with {peer}: {refusal:?}"));
+            return;
+        }
+    };
+
+    if let Err(e) = handle_connection(stream, registered, queued, HANDSHAKE_TIMEOUT) {
+        record(node, format!("Connection with {peer} ended: {e:#}"));
+    }
 }
 
 struct Registered {
@@ -496,6 +549,58 @@ mod tests {
             || true,
         )
         .expect_err("a write that cannot proceed must end the connection");
+    }
+
+    const SETTLED: Duration = Duration::from_millis(10);
+
+    fn a_backoff() -> Backoff {
+        Backoff::new(Duration::from_millis(1), Duration::from_millis(8))
+    }
+
+    #[test]
+    fn a_backoff_grows_and_stops_at_its_cap() {
+        let mut backoff = a_backoff();
+
+        let waits: Vec<_> = (0..6)
+            .map(|_| backoff.after(Duration::ZERO, SETTLED).as_millis())
+            .collect();
+
+        assert_eq!(
+            vec![1, 2, 4, 8, 8, 8],
+            waits,
+            "a peer that is simply gone must not become a busy loop, nor an \
+             ever-growing wait"
+        );
+    }
+
+    #[test]
+    fn a_connection_that_did_not_last_leaves_the_backoff_growing() {
+        let mut backoff = a_backoff();
+
+        let waits: Vec<_> = (0..4)
+            .map(|_| backoff.after(SETTLED - Duration::from_millis(1), SETTLED).as_millis())
+            .collect();
+
+        assert_eq!(
+            vec![1, 2, 4, 8],
+            waits,
+            "connecting is not succeeding: a peer that hangs up at once — which \
+             is us, under the checked-in config — must not hold us at 1ms"
+        );
+    }
+
+    #[test]
+    fn a_connection_that_lasted_starts_the_backoff_over() {
+        let mut backoff = a_backoff();
+        for _ in 0..3 {
+            backoff.after(Duration::ZERO, SETTLED);
+        }
+
+        assert_eq!(
+            Duration::from_millis(1),
+            backoff.after(SETTLED, SETTLED),
+            "a peer that worked and then went should be tried again promptly"
+        );
     }
 
     #[test]

--- a/test/functional/framework/network.py
+++ b/test/functional/framework/network.py
@@ -4,7 +4,7 @@ import socket
 from typing import List, Optional
 
 from .node import Node, Sandbox
-from .p2p import Peer, address_of, free_port
+from .p2p import Peer, address_of, free_port, listen_on
 
 
 class Network:
@@ -21,6 +21,12 @@ class Network:
     def listener(self) -> socket.socket:
         """A socket a node can be pointed at, so we see it dial out."""
         listening = free_port()
+        self._listeners.append(listening)
+        return listening
+
+    def listener_on(self, address: str) -> socket.socket:
+        """The same, on an address a node has already been told to dial."""
+        listening = listen_on(address)
         self._listeners.append(listening)
         return listening
 

--- a/test/functional/framework/p2p.py
+++ b/test/functional/framework/p2p.py
@@ -163,24 +163,18 @@ def split_address(address: str):
     return host, int(port)
 
 
-def free_port() -> socket.socket:
-    """A listening socket on an ephemeral port, kept open so nothing races us."""
-    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    listener.bind(("127.0.0.1", 0))
-    listener.listen(8)
-    return listener
-
-
 def listen_on(address: str) -> socket.socket:
-    """A listening socket on an address chosen by the caller, for the case a
-    node was told to dial something before anything was there to answer."""
+    """A listening socket, kept open so nothing races us onto the port."""
     listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     listener.bind(split_address(address))
     listener.listen(8)
 
     return listener
+
+
+def free_port() -> socket.socket:
+    return listen_on("127.0.0.1:0")
 
 
 def a_free_address() -> str:

--- a/test/functional/framework/p2p.py
+++ b/test/functional/framework/p2p.py
@@ -172,6 +172,17 @@ def free_port() -> socket.socket:
     return listener
 
 
+def listen_on(address: str) -> socket.socket:
+    """A listening socket on an address chosen by the caller, for the case a
+    node was told to dial something before anything was there to answer."""
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(split_address(address))
+    listener.listen(8)
+
+    return listener
+
+
 def a_free_address() -> str:
     """An address to hand a node *before* it exists, for the one case that needs
     it: a node configured to dial itself must know its port up front.

--- a/test/functional/test_reconnect.py
+++ b/test/functional/test_reconnect.py
@@ -1,0 +1,55 @@
+"""A configured address is an intent to stay connected, not one attempt.
+
+Peers learned by discovery are not covered: those come and go by design. These
+are the addresses an operator wrote down.
+"""
+
+import time
+
+from framework.p2p import IMPATIENCE, a_free_address, accept_within, address_of, expect_dialled
+
+
+def test_a_peer_that_is_down_at_boot_is_dialled_once_it_comes_up(net):
+    address = a_free_address()
+    node = net.node("--host-address", "127.0.0.1:0", "--addresses-to-connect", address)
+
+    # `listening_on` returns once the node is up, and it dials immediately after
+    # — to a closed loopback port, which is refused at once. The pause is so the
+    # first attempt has reliably failed before anything is there to answer, or
+    # the test would pass without a retry ever happening.
+    node.listening_on()
+    time.sleep(0.3)
+
+    peer = net.track(expect_dialled(net.listener_on(address)))
+
+    assert peer.next_frame().command == "version"
+
+
+def test_a_configured_peer_that_drops_mid_session_is_dialled_again(net):
+    listening = net.listener()
+    net.node(
+        "--host-address", "127.0.0.1:0", "--addresses-to-connect", address_of(listening)
+    )
+
+    first = net.track(expect_dialled(listening))
+    assert first.next_frame().command == "version"
+    first.close()
+
+    second = net.track(expect_dialled(listening))
+    assert second.next_frame().command == "version", "the node gave up after one loss"
+
+
+def test_a_connection_that_is_still_alive_is_not_dialled_a_second_time(net):
+    listening = net.listener()
+    net.node(
+        "--host-address", "127.0.0.1:0", "--addresses-to-connect", address_of(listening)
+    )
+
+    peer = net.track(expect_dialled(listening))
+    peer.handshake()
+
+    # Long enough for several retries had the node been counting them: the
+    # first would be due a second after the connection ended.
+    assert accept_within(listening, IMPATIENCE) is None, (
+        "a peer we are already connected to must not be dialled again"
+    )

--- a/test/functional/test_reconnect.py
+++ b/test/functional/test_reconnect.py
@@ -4,8 +4,6 @@ Peers learned by discovery are not covered: those come and go by design. These
 are the addresses an operator wrote down.
 """
 
-import time
-
 from framework.p2p import IMPATIENCE, a_free_address, accept_within, address_of, expect_dialled
 
 
@@ -13,12 +11,10 @@ def test_a_peer_that_is_down_at_boot_is_dialled_once_it_comes_up(net):
     address = a_free_address()
     node = net.node("--host-address", "127.0.0.1:0", "--addresses-to-connect", address)
 
-    # `listening_on` returns once the node is up, and it dials immediately after
-    # — to a closed loopback port, which is refused at once. The pause is so the
-    # first attempt has reliably failed before anything is there to answer, or
-    # the test would pass without a retry ever happening.
-    node.listening_on()
-    time.sleep(0.3)
+    # Synchronisation, not the assertion: nothing is listening yet, and binding
+    # before the first dial has failed would green this test without a retry
+    # ever happening. The guarantee below is still asserted on bytes.
+    node.line_containing("Could not connect to")
 
     peer = net.track(expect_dialled(net.listener_on(address)))
 


### PR DESCRIPTION
Closes #43. Adds [ADR-0016](https://github.com/matheusavi/avicoin/blob/feat/reconnect-with-backoff/docs/adr/0016-reconnecting-to-configured-peers.md).

> ⚠️ **Stacked on #48**, which is stacked on #47. Base is `feat/ready-gated-relay`, so the diff here is only this ticket. Merge order: #47 → #48 → this.

`main` dialled each configured address once. A peer down at that moment was lost until restart, and so was one that dropped later.

### Shape

Each configured address gets a thread that dials, **waits out the connection**, backs off, and dials again. A live connection cannot be redialled because the thread that would is blocked on it — no flag to keep in step, no check to race. That is the whole of "does not create a duplicate peer entry for a connection that is still alive".

### The backoff rule is the interesting part

"Grow on failure, reset on success" is the obvious rule, and it is **wrong here** — the repo's own `config.toml` is the counterexample. It points `host_address` and `addresses_to_connect` at the same address, so the default setup dials itself; since #41 that connection is recognised and dropped *after* the TCP connect succeeded. Under the obvious rule: connect (reset to 1s) → handshake → recognise ourselves → drop → wait 1s → forever, at one dial per second, out of the box. The backoff would never grow, because every attempt "succeeds".

So a connection has to have **lasted** (10s) to reset it. A self-connection dies in milliseconds and climbs to the 60s cap; a real peer resets it.

### What review caught

Two genuine defects, both in the second commit:

**The clock started in the wrong place.** `Instant::now()` sat before `TcpStream::connect`, so a *failed* dial counted as time connected. On loopback a refusal is instant, so nothing noticed — but a blackholed address sits in `connect()` for ~2 minutes on Linux, well past `settled`, so every failure would reset the backoff and it would never grow. That is the AC's own case ("a peer that is simply gone") failing. `dial` now returns `Duration::ZERO` when it never connected, so the mistake can't be re-spelled.

**A panic ended retries permanently.** The retry thread ran the connection inline, so a panic anywhere in the connection path killed the loop while the process carried on — that address silently never dialled again. It spawns and joins now, so a panic costs one connection, as before.

| Mutation | Caught by |
|---|---|
| Dial once, never retry | 2 functional |
| The backoff never grows | 1 Rust |
| The backoff is uncapped | 1 Rust |
| Connecting counts as succeeding (the ADR's rejected rule) | 2 Rust |
| A failed dial counts as time connected (the bug above) | 1 Rust |

### One criterion I'd argue about

> A test drives the retry schedule without waiting real backoff durations

The *schedule* — `Backoff::after` — is driven at millisecond scale, and the ADR's rule with it. The **loop** is covered functionally and does pay the real 1s first delay. Driving the loop itself without real time would need a stop condition the node has no concept of, and a test thread dialling loopback forever afterwards. I judged that a worse trade; say if you'd rather have it.

183 Rust tests, 41 functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)