### PR TITLE
Keep eight slots that only a dial can fill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ The node is a small P2P server modeled on Bitcoin's message framing. `main.rs` b
 
 `keep_connected` waits out its connection before dialling again, so a live one cannot be redialled — no check to race. The backoff resets only when a connection *lasted* `Retry::settled`, timed from the connect rather than from the attempt. [ADR-0016](docs/adr/0016-reconnecting-to-configured-peers.md) has both reasons; the checked-in `config.toml` is the counterexample that produced the first.
 
-`spawn_connection` registers the peer in `node.peers` before handing off, and a `Registered` guard removes it on any exit including a panic. A connection refused at `MAX_PEERS` is dropped there and never becomes a thread pair.
+`spawn_connection` registers the peer in `node.peers` before handing off, and a `Registered` guard removes it on any exit including a panic. A refused connection — `MAX_PEERS`, or `MAX_INBOUND` for an accepted one ([ADR-0018](docs/adr/0018-reserved-outbound-slots.md)) — is dropped there and never becomes a thread pair.
 
 Each connection then runs `handle_connection`, which splits into **two threads** over `try_clone()`d socket handles, joined by a *bounded* `sync_channel` of already-framed bytes:
 - the **reader** blocks in `read` under the handshake timeout, appends to a growing `recv_buffer`, drains complete messages out of it, and *enqueues* replies (Ping → Pong, Version → Verack) rather than writing them;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,9 +96,15 @@ than evict an established peer — there is no peer scoring to evict on yet. The
 cap exists because each connection may legally hold `MAX_PAYLOAD_SIZE` in its
 `recv_buffer`, so the exposure is `peers × 32 MiB`; this bounds the multiplier
 without making it small, and lowering the per-connection ceiling is separate
-work. Inbound and outbound share the cap, so a flood of inbound connections can
-crowd out configured dials — acceptable while peers come from a static list, not
-once discovery lands in M2.
+work.
+
+**Inbound and outbound do not share it.** Accepted connections may take at most
+`MAX_INBOUND` (24) slots; the remaining `RESERVED_OUTBOUND` (8) can only be
+filled by a connection this node chose to make. Without that, 32 inbound
+connections leave nowhere to dial from, and every peer the node can see is one
+the attacker allowed — the eclipse-attack precondition.
+[ADR-0018](adr/0018-reserved-outbound-slots.md) has the alternatives, and states
+plainly what it costs: a listen-only node accepts 24 rather than 32.
 
 The two threads share a fate, in both directions. The reader ending releases the
 registration — before joining the writer, or the sender it holds would keep the

--- a/docs/adr/0018-reserved-outbound-slots.md
+++ b/docs/adr/0018-reserved-outbound-slots.md
@@ -1,0 +1,59 @@
+# ADR-0018 — Inbound connections may not take every slot
+
+- **Status:** Accepted
+- **Date:** 2026-08-08
+- **Deciders:** @matheusavi
+
+## Context
+
+`MAX_PEERS` (32) was shared between connections we dial and connections we
+accept, first come first served. [ARCHITECTURE](../ARCHITECTURE.md) recorded that
+as acceptable "while peers come from a static list, not once discovery lands in
+M2". Discovery has landed.
+
+Sharing the cap hands an attacker a lever: open 32 connections and the node has
+nowhere left to dial from, so **every peer it can see is one the attacker
+allowed**. That is the precondition for an eclipse attack, and it is cheap to
+close here because the peer table is the only thing counting connections.
+
+## Decision
+
+**Inbound connections may occupy at most `MAX_INBOUND` (24) slots. The remaining
+`RESERVED_OUTBOUND` (8) can only ever be filled by connections this node chose to
+make.** Outbound is not capped below `MAX_PEERS`: it may use slots inbound is not
+using.
+
+A refusal for this reason is `Refused::InboundFull`, distinct from
+`Refused::AtCapacity`, so a log says which bound was hit.
+
+## Alternatives
+
+**Two independent caps** — `MAX_INBOUND` inbound *and* `MAX_OUTBOUND` outbound,
+never trading. Rejected: a node with a long seed list could not use slots no
+inbound peer wanted, and the second cap has to be tuned against a number
+(`MAX_PEERS`) that is already arbitrary.
+
+**Evict an inbound peer when a dial needs a slot.** Rejected for now: eviction
+needs a policy for *which* peer, and there is no peer scoring to base one on.
+Refusing the newcomer is the rule everywhere else in the table
+([ARCHITECTURE](../ARCHITECTURE.md#concurrency-model)); making one case behave
+differently would be the surprising choice.
+
+**Leave it and rely on the dial budget.** Rejected: `MAX_DIALS_IN_FLIGHT`
+([ADR-0017](0017-peer-discovery.md)) bounds how many dials are *in progress*, not
+whether any can succeed. A full table refuses them at registration regardless.
+
+## Consequences
+
+- A node under an inbound flood keeps eight slots to dial configured and
+  discovered peers with. The flood is still served — up to 24 of it.
+- **A listen-only node accepts 24 rather than 32.** Named here because the ticket
+  asked for it: an unstated policy is how a node ends up quietly refusing the
+  peer it most wanted. Nothing is lost that the node was using — the reservation
+  only bites once 24 inbound peers are already connected.
+- The reservation is by *origin*, which is exactly what
+  [ADR-0015](0015-peer-identity-and-duplicate-connections.md)'s tie-break already
+  turns on. A peer that reaches us both ways still collapses to one connection,
+  and which one it keeps decides which budget it lands in.
+- Nothing yet distinguishes a *useful* outbound peer from one that is merely
+  dialled. When peer scoring exists, this reservation is where it should apply.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,6 +45,7 @@ a number.
 | [0015](0015-peer-identity-and-duplicate-connections.md) | Peer identity is the version nonce, and duplicates break the tie by it | Accepted |
 | [0016](0016-reconnecting-to-configured-peers.md) | A connection has to last before it resets the backoff | Accepted |
 | [0017](0017-peer-discovery.md) | Discovery needs to push, not only pull | Accepted |
+| [0018](0018-reserved-outbound-slots.md) | Inbound connections may not take every slot | Accepted |
 
 [TEMPLATE.md](TEMPLATE.md) is the starting point for a new record. It is not an
 ADR and holds no number.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -233,6 +233,10 @@ Bitcoin · 🅧 deferred out of v1 by [ADR-0001](adr/0001-v1-scope.md).
 - **MAX_PEERS / OUTBOUND_QUEUE** ✅ — 32 connections, 128 queued messages each.
   At either limit the peer is **refused** or **dropped**, never made to wait: a
   blocking send would stall the whole node on one slow socket.
+- **MAX_INBOUND / RESERVED_OUTBOUND** ✅ (ADR-0018) — 24 and 8. Accepted
+  connections may take at most `MAX_INBOUND` slots, so a flood cannot leave a
+  node with nowhere to dial from and no view but the attacker's. Outbound is not
+  capped below `MAX_PEERS`; it may use what inbound is not using.
 - **Log** ✅ — the node's bounded in-memory record of recent
   activity, `LOG_CAPACITY` (512) entries, oldest evicted first. Every entry also
   goes to stdout; the buffer exists so M6's HTTP API can serve recent activity

--- a/src/node.rs
+++ b/src/node.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc::{SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 
 pub const MAX_PEERS: usize = 32;
-/// Slots inbound connections may never take — ADR-0018.
+// ADR-0018.
 pub const RESERVED_OUTBOUND: usize = 8;
 pub const MAX_INBOUND: usize = MAX_PEERS - RESERVED_OUTBOUND;
 pub const OUTBOUND_QUEUE: usize = 128;
@@ -120,7 +120,7 @@ impl PeerTable {
         Ok(id)
     }
 
-    pub fn count(&self, origin: Origin) -> usize {
+    fn count(&self, origin: Origin) -> usize {
         self.peers
             .values()
             .filter(|peer| peer.origin == origin)
@@ -428,7 +428,6 @@ mod tests {
         (id, queued)
     }
 
-    /// Fills every slot, which only outbound connections may do.
     fn a_full_table() -> (PeerTable, Vec<Receiver<Vec<u8>>>) {
         let mut table = PeerTable::default();
         let queues = (0..MAX_PEERS)
@@ -990,7 +989,7 @@ mod tests {
     }
 
     #[test]
-    fn a_node_with_nothing_to_dial_still_accepts_a_useful_number_of_peers() {
+    fn a_node_nobody_dials_out_to_still_fills_most_of_its_table() {
         let mut table = PeerTable::default();
         let mut queues = Vec::new();
 
@@ -998,12 +997,24 @@ mod tests {
             queues.push(a_peer(&mut table, 5000 + index as u16).1);
         }
 
-        assert_eq!(
-            MAX_INBOUND,
-            table.count(Origin::Accepted),
-            "the reservation costs a listen-only node {RESERVED_OUTBOUND} slots, \
-             and must not cost it more"
+        // Against the table's own size, not against MAX_INBOUND, which would be
+        // the constant asserted against itself and would move with any change
+        // to it. The reservation may cost a listen-only node slots; it may not
+        // cost it most of them.
+        assert!(
+            table.len() > MAX_PEERS / 2,
+            "{} of {MAX_PEERS} slots left to a node nobody dials out to",
+            table.len()
         );
+    }
+
+    #[test]
+    fn the_reservation_is_the_size_the_documents_say() {
+        // Literals: asserting MAX_INBOUND == MAX_PEERS - RESERVED_OUTBOUND
+        // proves arithmetic, and moves silently with whatever it is measuring.
+        assert_eq!(32, MAX_PEERS);
+        assert_eq!(8, RESERVED_OUTBOUND);
+        assert_eq!(24, MAX_INBOUND);
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -6,6 +6,9 @@ use std::sync::mpsc::{SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 
 pub const MAX_PEERS: usize = 32;
+/// Slots inbound connections may never take — ADR-0018.
+pub const RESERVED_OUTBOUND: usize = 8;
+pub const MAX_INBOUND: usize = MAX_PEERS - RESERVED_OUTBOUND;
 pub const OUTBOUND_QUEUE: usize = 128;
 
 pub type PeerId = u64;
@@ -62,6 +65,7 @@ pub struct PeerHandle {
 #[derive(Debug, PartialEq, Eq)]
 pub enum Refused {
     AtCapacity,
+    InboundFull,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -95,6 +99,10 @@ impl PeerTable {
             return Err(Refused::AtCapacity);
         }
 
+        if origin == Origin::Accepted && self.count(Origin::Accepted) >= MAX_INBOUND {
+            return Err(Refused::InboundFull);
+        }
+
         let id = self.next_id;
         self.next_id += 1;
         self.peers.insert(
@@ -110,6 +118,13 @@ impl PeerTable {
         );
 
         Ok(id)
+    }
+
+    pub fn count(&self, origin: Origin) -> usize {
+        self.peers
+            .values()
+            .filter(|peer| peer.origin == origin)
+            .count()
     }
 
     fn holding(&self, nonce: u64) -> Option<PeerId> {
@@ -398,11 +413,29 @@ mod tests {
     }
 
     fn a_peer(table: &mut PeerTable, port: u16) -> (PeerId, Receiver<Vec<u8>>) {
+        a_peer_from(table, port, Origin::Accepted)
+    }
+
+    fn a_peer_from(
+        table: &mut PeerTable,
+        port: u16,
+        origin: Origin,
+    ) -> (PeerId, Receiver<Vec<u8>>) {
         let (outbound, queued) = sync_channel(OUTBOUND_QUEUE);
         let id = table
-            .register(address(port), Origin::Accepted, outbound)
+            .register(address(port), origin, outbound)
             .expect("registering the first peers should succeed");
         (id, queued)
+    }
+
+    /// Fills every slot, which only outbound connections may do.
+    fn a_full_table() -> (PeerTable, Vec<Receiver<Vec<u8>>>) {
+        let mut table = PeerTable::default();
+        let queues = (0..MAX_PEERS)
+            .map(|index| a_peer_from(&mut table, 5000 + index as u16, Origin::Dialled).1)
+            .collect();
+
+        (table, queues)
     }
 
     #[test]
@@ -924,29 +957,72 @@ mod tests {
         let mut queues = Vec::new();
 
         for index in 0..MAX_PEERS - 1 {
-            queues.push(a_peer(&mut table, 5000 + index as u16).1);
+            queues.push(a_peer_from(&mut table, 5000 + index as u16, Origin::Dialled).1);
         }
         assert!(table.has_room(), "one short of the cap is still room");
 
-        queues.push(a_peer(&mut table, 6000).1);
+        queues.push(a_peer_from(&mut table, 6000, Origin::Dialled).1);
 
         assert!(!table.has_room());
     }
 
     #[test]
-    fn a_full_table_refuses_the_next_peer() {
+    fn inbound_connections_cannot_take_the_slots_kept_for_dialling() {
         let mut table = PeerTable::default();
         let mut queues = Vec::new();
 
-        for index in 0..MAX_PEERS {
+        for index in 0..MAX_INBOUND {
             queues.push(a_peer(&mut table, 5000 + index as u16).1);
         }
+
+        let (outbound, _refused) = sync_channel(OUTBOUND_QUEUE);
+        assert_eq!(
+            Err(Refused::InboundFull),
+            table.register(address(6000), Origin::Accepted, outbound),
+            "an attacker who can fill every slot decides who this node sees"
+        );
+
+        let (outbound, _dialled) = sync_channel(OUTBOUND_QUEUE);
+        assert!(
+            table.register(address(6001), Origin::Dialled, outbound).is_ok(),
+            "the point of the reservation is that dialling still works"
+        );
+    }
+
+    #[test]
+    fn a_node_with_nothing_to_dial_still_accepts_a_useful_number_of_peers() {
+        let mut table = PeerTable::default();
+        let mut queues = Vec::new();
+
+        for index in 0..MAX_INBOUND {
+            queues.push(a_peer(&mut table, 5000 + index as u16).1);
+        }
+
+        assert_eq!(
+            MAX_INBOUND,
+            table.count(Origin::Accepted),
+            "the reservation costs a listen-only node {RESERVED_OUTBOUND} slots, \
+             and must not cost it more"
+        );
+    }
+
+    #[test]
+    fn dialled_peers_may_use_the_whole_table() {
+        let (table, _queues) = a_full_table();
+
+        assert_eq!(MAX_PEERS, table.len());
+        assert_eq!(MAX_PEERS, table.count(Origin::Dialled));
+    }
+
+    #[test]
+    fn a_full_table_refuses_the_next_peer() {
+        let (mut table, _queues) = a_full_table();
         assert_eq!(MAX_PEERS, table.len());
 
         let (outbound, _refused) = sync_channel(OUTBOUND_QUEUE);
         assert_eq!(
             Err(Refused::AtCapacity),
-            table.register(address(6000), Origin::Accepted, outbound),
+            table.register(address(6000), Origin::Dialled, outbound),
             "the policy is to refuse the newcomer, not to evict an established peer"
         );
         assert_eq!(MAX_PEERS, table.len());

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -535,6 +535,7 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::node::Node;
+    use rstest::rstest;
 
     const NEVER: Duration = Duration::from_secs(3600);
 
@@ -1462,21 +1463,24 @@ mod tests {
         }
     }
 
-    #[test]
-    fn a_refused_connection_leaves_the_table_as_it_found_it() {
+    #[rstest]
+    #[case::every_slot_taken(crate::node::MAX_PEERS, Origin::Dialled)]
+    #[case::inbound_share_taken(crate::node::MAX_INBOUND, Origin::Accepted)]
+    fn a_refused_connection_leaves_the_table_as_it_found_it(
+        #[case] fill: usize,
+        #[case] origin: Origin,
+    ) {
         let node = a_node();
         let mut held = Vec::new();
 
-        for index in 0..crate::node::MAX_PEERS {
+        for index in 0..fill {
             let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
             held.push(queued);
             let filler = format!("127.0.0.1:{}", 5000 + index).parse().unwrap();
-            // Dialled: inbound cannot fill the table, which is the point of
-            // the reservation and is covered in node.rs.
             node.lock()
                 .unwrap()
                 .peers
-                .register(filler, Origin::Dialled, outbound)
+                .register(filler, origin, outbound)
                 .expect("the table should accept peers up to its bound");
         }
 
@@ -1491,7 +1495,7 @@ mod tests {
             "a refused peer should be hung up on, not left connected in silence"
         );
         assert_eq!(
-            crate::node::MAX_PEERS,
+            fill,
             node.lock().unwrap().peers.len(),
             "a refused connection must not displace an established peer"
         );

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1471,10 +1471,12 @@ mod tests {
             let (outbound, queued) = mpsc::sync_channel(OUTBOUND_QUEUE);
             held.push(queued);
             let filler = format!("127.0.0.1:{}", 5000 + index).parse().unwrap();
+            // Dialled: inbound cannot fill the table, which is the point of
+            // the reservation and is covered in node.rs.
             node.lock()
                 .unwrap()
                 .peers
-                .register(filler, Origin::Accepted, outbound)
+                .register(filler, Origin::Dialled, outbound)
                 .expect("the table should accept peers up to its bound");
         }
 

--- a/test/functional/test_inbound_pressure.py
+++ b/test/functional/test_inbound_pressure.py
@@ -1,0 +1,44 @@
+"""A node can always reach out, however many connections reach in."""
+
+from framework.p2p import a_free_address, address_of, expect_dialled
+
+# More than MAX_PEERS (32), so under a shared cap the flood would take every
+# slot and the configured dial below would be refused.
+A_FLOOD = 40
+
+
+def test_an_inbound_flood_still_leaves_room_to_reach_a_configured_peer(net):
+    wanted = a_free_address()
+    node = net.node("--host-address", "127.0.0.1:0", "--addresses-to-connect", wanted)
+    address = node.listening_on()
+
+    # Its first dial fails, so the node is retrying while the flood arrives.
+    node.line_containing("Could not connect to")
+
+    for _ in range(A_FLOOD):
+        net.dial(address)
+
+    peer = net.track(expect_dialled(net.listener_on(wanted)))
+
+    assert peer.next_frame().command == "version", (
+        "an attacker who can fill every slot decides who this node may see"
+    )
+
+
+def test_a_node_nobody_dials_out_to_still_accepts_a_crowd(net):
+    """The reservation costs a listen-only node slots; it must not cost it the
+    ability to serve peers at all."""
+    node = net.node("--host-address", "127.0.0.1:0")
+    address = node.listening_on()
+
+    crowd = [net.dial(address) for _ in range(A_FLOOD)]
+
+    served = 0
+    for peer in crowd:
+        try:
+            peer.handshake()
+            served += 1
+        except AssertionError:
+            pass
+
+    assert served >= 16, f"only {served} of {A_FLOOD} inbound peers were served"

--- a/test/functional/test_inbound_pressure.py
+++ b/test/functional/test_inbound_pressure.py
@@ -1,10 +1,27 @@
 """A node can always reach out, however many connections reach in."""
 
-from framework.p2p import a_free_address, address_of, expect_dialled
+from framework.p2p import a_free_address, expect_dialled
 
-# More than MAX_PEERS (32), so under a shared cap the flood would take every
-# slot and the configured dial below would be refused.
-A_FLOOD = 40
+# Enough to outlast any sane peer cap, so the test does not have to know one.
+GIVE_UP_AFTER = 128
+
+
+def crowd_out(net, address) -> int:
+    """Dial until the node stops serving new connections, and say how many it
+    served. Measured rather than assumed: the peer caps are Rust constants this
+    side cannot see, and guessing one is how a test passes vacuously after
+    somebody raises it."""
+    served = 0
+
+    for _ in range(GIVE_UP_AFTER):
+        peer = net.dial(address)
+        # A served connection opens with the node's version; a refused one is
+        # closed, and yields nothing.
+        if not peer.frames_within(0.2):
+            return served
+        served += 1
+
+    raise AssertionError(f"the node served {GIVE_UP_AFTER} inbound connections")
 
 
 def test_an_inbound_flood_still_leaves_room_to_reach_a_configured_peer(net):
@@ -12,33 +29,14 @@ def test_an_inbound_flood_still_leaves_room_to_reach_a_configured_peer(net):
     node = net.node("--host-address", "127.0.0.1:0", "--addresses-to-connect", wanted)
     address = node.listening_on()
 
-    # Its first dial fails, so the node is retrying while the flood arrives.
+    # Its first dial failed, so the node is retrying while the flood arrives.
     node.line_containing("Could not connect to")
 
-    for _ in range(A_FLOOD):
-        net.dial(address)
+    served = crowd_out(net, address)
+    assert served > 0, "the node refused every inbound connection"
 
     peer = net.track(expect_dialled(net.listener_on(wanted)))
 
     assert peer.next_frame().command == "version", (
         "an attacker who can fill every slot decides who this node may see"
     )
-
-
-def test_a_node_nobody_dials_out_to_still_accepts_a_crowd(net):
-    """The reservation costs a listen-only node slots; it must not cost it the
-    ability to serve peers at all."""
-    node = net.node("--host-address", "127.0.0.1:0")
-    address = node.listening_on()
-
-    crowd = [net.dial(address) for _ in range(A_FLOOD)]
-
-    served = 0
-    for peer in crowd:
-        try:
-            peer.handshake()
-            served += 1
-        except AssertionError:
-            pass
-
-    assert served >= 16, f"only {served} of {A_FLOOD} inbound peers were served"


### PR DESCRIPTION
Closes #45 — the last M2 ticket. Adds [ADR-0018](https://github.com/matheusavi/avicoin/blob/feat/reserved-outbound-slots/docs/adr/0018-reserved-outbound-slots.md).

> ⚠️ **Stacked on #50 → #49 → #48 → #47.** Merge order: #47 → #48 → #49 → #50 → this.

`MAX_PEERS` was shared between connections we make and connections we accept, first come first served. Open 32 and the node has nowhere left to dial from, so **every peer it can see is one the attacker allowed** — the eclipse-attack precondition. ARCHITECTURE already recorded the sharing as acceptable only *"while peers come from a static list, not once discovery lands in M2"*.

Accepted connections may now take at most `MAX_INBOUND` (24). The other eight can only be filled by a connection this node chose to make. Outbound keeps the whole table as its ceiling, so it can use what inbound isn't.

The ticket asked for the policy to be *stated* rather than inferred, so ADR-0018 carries the three rejected shapes — two independent caps, evicting an inbound peer, and relying on #44's dial budget — and says plainly what the choice costs.

### The criterion I'd like you to rule on

> The reservation does not stop a node accepting inbound peers when it has no interest in dialling

**A listen-only node accepts 24 rather than 32.** On the literal wording that passes — it is not stopped, and there's now a test that it keeps *most* of the table. But the reservation isn't conditioned on dialling interest at all, and the reviewer's push-back is fair: stating a cost isn't the same as meeting the criterion.

I didn't condition it, and the reason is that the obvious signal is wrong. "Has configured addresses" is the only thing cheap to check, and a node with an empty seed list still learns addresses from inbound gossip and still wants to dial them — so it *does* have interest. Conditioning on config would reserve nothing for exactly the node that most needs discovery. I'd rather flag the disagreement than quietly pick the reading that suits me.

### What review caught

**The test guarding the reservation's size was a tautology** — register `MAX_INBOUND` peers, assert `MAX_INBOUND` peers registered. It stayed green with `RESERVED_OUTBOUND = 30`, so the ADR's own stated consequence was unguarded. It measures against the table's size now.

**The functional test guessed at constants Python can't see** — a flood of 40 against a cap of 32, and "at least 16 served" against an inbound share of 24. Raise `MAX_PEERS` and both pass while proving nothing. It dials until the node stops serving instead. Its listen-only half moved to Rust, where the constants live: it had been swallowing every `AssertionError` the framework raises, so a wholly broken handshake was indistinguishable from a designed refusal.

| Mutation | Caught by |
|---|---|
| Inbound may take every slot again | 2 Rust + 1 functional |
| The reservation applies to outbound too | 5 Rust + 1 functional |
| The reservation swallows most of the table | 2 Rust |

217 Rust tests, 55 functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)